### PR TITLE
7 class selection for testing

### DIFF
--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/actions/GenerateTestsAction.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/actions/GenerateTestsAction.kt
@@ -38,4 +38,9 @@ class GenerateTestsAction : AnAction() {
         AppExecutorUtil.getAppScheduledExecutorService().execute(EvoSuiteResultWatcher(project, resultPath))
     }
 
+    override fun update(e: AnActionEvent) {
+        val psiElement = e.dataContext.getData(CommonDataKeys.PSI_ELEMENT)
+        e.presentation.isVisible = psiElement is PsiClass
+    }
+
 }

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/actions/GenerateTestsAction.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/actions/GenerateTestsAction.kt
@@ -29,7 +29,12 @@ class GenerateTestsAction : AnAction() {
         psiFile ?: return
 
         val mainClass: PsiClass = PsiTreeUtil.findChildOfType(psiFile, PsiClass::class.java) ?: return
-        val classFQN = mainClass.qualifiedName ?: return
+        val classFileFQN = mainClass.qualifiedName ?: return
+
+        val psiElement = e.dataContext.getData(CommonDataKeys.PSI_ELEMENT)
+        val classFQN = classFileFQN.substring(0, classFileFQN.lastIndexOf(".") + 1)
+                            .plus(psiElement.toString().split(":")[1])
+        println(classFQN)
 
         log.info("Selected class is $classFQN")
 
@@ -40,6 +45,7 @@ class GenerateTestsAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val psiElement = e.dataContext.getData(CommonDataKeys.PSI_ELEMENT)
+        println(psiElement)
         e.presentation.isVisible = psiElement is PsiClass
     }
 

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/actions/GenerateTestsAction.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/actions/GenerateTestsAction.kt
@@ -28,13 +28,21 @@ class GenerateTestsAction : AnAction() {
         val psiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE)
         psiFile ?: return
 
+        val psiElement = e.dataContext.getData(CommonDataKeys.PSI_ELEMENT)
+
+        //TODO: handle the element being a method
+        if (psiElement !is PsiClass) {
+            val surroundingClass = PsiTreeUtil.getParentOfType(psiElement, PsiElement::class.java)
+            println("selected ${psiElement.toString().split(":")[0].substring(3)}"
+                    + "${psiElement.toString().split(":")[1]} of class $surroundingClass")
+            return
+        }
+
         val mainClass: PsiClass = PsiTreeUtil.findChildOfType(psiFile, PsiClass::class.java) ?: return
         val classFileFQN = mainClass.qualifiedName ?: return
 
-        val psiElement = e.dataContext.getData(CommonDataKeys.PSI_ELEMENT)
         val classFQN = classFileFQN.substring(0, classFileFQN.lastIndexOf(".") + 1)
                             .plus(psiElement.toString().split(":")[1])
-        println(classFQN)
 
         log.info("Selected class is $classFQN")
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,12 +33,12 @@
 
     <actions>
         <group id="TestGenie.TestGenieActions" text="TestGenie" description="Actions related to TestGenie" popup="true">
-            <add-to-group group-id="CodeMenu" anchor="after" relative-to-action="Generate"/>
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
             <action class="com.github.mitchellolsthoorn.testgenie.actions.GenerateTestsAction"
-                    id="TestGenie.TestGenieActions.GenerateTestsAction"
-                    text="Generate Tests"
-                    description="Press to generate tests using the best test generating software TestGenie">
-                <keyboard-shortcut first-keystroke="control alt shift G" second-keystroke="T" keymap="$default"/>
+                    id="TestGenie.TestGenieActions.GenerateTestsForClass"
+                    text="Generate Tests For Class"
+                    description="Generate tests for the selected class using TestGenie">
+                <keyboard-shortcut first-keystroke="control alt shift G" second-keystroke="C" keymap="$default"/>
             </action>
         </group>
     </actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -34,7 +34,7 @@
     <actions>
         <group id="TestGenie.TestGenieActions" text="TestGenie" description="Actions related to TestGenie" popup="true">
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
-            <action class="com.github.mitchellolsthoorn.testgenie.actions.GenerateTestsAction"
+            <action class="com.github.mitchellolsthoorn.testgenie.actions.GenerateTestsActionClass"
                     id="TestGenie.TestGenieActions.GenerateTestsForClass"
                     text="Generate Tests For Class"
                     description="Generate tests for the selected class using TestGenie">


### PR DESCRIPTION
# Description of changes made
- Use the values of the parameters in settings menu and tool window to invoke EvoSuite
- Make the `GenerateTestAction` class to appear on the *right click* (instead of in the `Code` section) and rename it to `GenerateTestActionClass` to separate it from the analogous class for generating tests for methods
- Make the action visible only if a class has been selected
- Make it possible to generate tests for a class in case of multiple classes in one `.java` file

# Why is merge request needed
- It is now possible to call EvoSuite with the parameters values that the user/developer wants
- Test generation for a class now can only happen if the actual class is selected
- Multi-class `.java` files are also handled now 

# Other notes


# What is missing?
- Add test generation for methods (will be addressed in #9 )
- (Optional) Refactoring 

- [x] I have checked that I am merging into correct branch
