### PR TITLE
Basic coverage visualisation

### DIFF
--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/coverage/TestGenieCoverageRenderer.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/coverage/TestGenieCoverageRenderer.kt
@@ -1,0 +1,84 @@
+package com.github.mitchellolsthoorn.testgenie.coverage
+
+import com.intellij.codeInsight.hint.HintManager
+import com.intellij.codeInsight.hint.HintManagerImpl
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.ex.EditorGutterComponentEx
+import com.intellij.openapi.editor.markup.ActiveGutterRenderer
+import com.intellij.openapi.editor.markup.LineMarkerRendererEx
+import com.intellij.ui.HintHint
+import com.intellij.ui.LightweightHint
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.FormBuilder
+import java.awt.Color
+import java.awt.Graphics
+import java.awt.Rectangle
+import java.awt.event.MouseEvent
+
+class TestGenieCoverageRenderer(private val color: Color, private val lineNumber : Int, private val tests : List<String>) : ActiveGutterRenderer,
+    LineMarkerRendererEx {
+
+    /**
+     * Perform the action - show toolTip on mouse click.
+     *
+     * @param editor the editor
+     * @param e mouse event
+     */
+    override fun doAction(editor: Editor, e: MouseEvent) {
+        e.consume()
+        val panel = FormBuilder
+            .createFormBuilder()
+            .addComponent(JBLabel(" Covered by tests: $tests "), 10)
+            .addVerticalGap(10)
+            .panel
+
+        val hint = LightweightHint(panel)
+        val point = HintManagerImpl.getHintPosition(hint, editor, LogicalPosition(lineNumber, 0), HintManager.RIGHT)
+        HintManagerImpl.getInstanceImpl().showEditorHint(
+            hint,
+            editor,
+            point,
+            HintManager.HIDE_BY_ANY_KEY or HintManager.HIDE_BY_TEXT_CHANGE or HintManager.HIDE_BY_OTHER_HINT or HintManager.HIDE_BY_SCROLLING,
+            -1,
+            false,
+            HintHint(editor, point)
+        )
+    }
+
+    /**
+     * Test if action can be performed - mouse is within the gutter.
+     *
+     * @param editor the editor
+     * @param e mouse event
+     * @return true iff mouse has interacted with gutter
+     */
+    override fun canDoAction(editor: Editor, e: MouseEvent): Boolean {
+        val component = e.component
+        if (component is EditorGutterComponentEx) {
+            return e.x > component.lineMarkerAreaOffset && e.x < component.iconAreaOffset
+        }
+        return false
+    }
+
+    /**
+     * Sets area to paint in given color.
+     *
+     * @param editor the editor
+     * @param g graphics used to draw
+     * @param r rectangle object
+     */
+    override fun paint(editor: Editor, g: Graphics, r: Rectangle) {
+        g.fillRect(r.x, r.y, r.width, r.height)
+        g.color = color
+    }
+
+    /**
+     * Getter for offset of gutter color.
+     *
+     * @return position
+     */
+    override fun getPosition(): LineMarkerRendererEx.Position {
+        return LineMarkerRendererEx.Position.LEFT
+    }
+}

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/coverage/TestGenieCoverageRenderer.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/coverage/TestGenieCoverageRenderer.kt
@@ -16,6 +16,13 @@ import java.awt.Graphics
 import java.awt.Rectangle
 import java.awt.event.MouseEvent
 
+/**
+ * This class extends the line marker and gutter editor to allow more functionality.
+ * 
+ * @param color color of marker
+ * @param lineNumber lineNumber to color
+ * @param tests list of tests that cover this line
+ */
 class TestGenieCoverageRenderer(private val color: Color, private val lineNumber : Int, private val tests : List<String>) : ActiveGutterRenderer,
     LineMarkerRendererEx {
 

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/listener/TestGenerationResultListenerImpl.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/listener/TestGenerationResultListenerImpl.kt
@@ -1,6 +1,7 @@
 package com.github.mitchellolsthoorn.testgenie.listener
 
 import com.github.mitchellolsthoorn.testgenie.evosuite.TestGenerationResultListener
+import com.github.mitchellolsthoorn.testgenie.services.CoverageVisualisationService
 import com.github.mitchellolsthoorn.testgenie.services.TestCaseDisplayService
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
@@ -19,6 +20,12 @@ class TestGenerationResultListenerImpl(private val project: Project) : TestGener
         val tests = testReport.testCaseList.values.map { it.testCode }
         ApplicationManager.getApplication().invokeLater {
             testCaseDisplayService.displayTestCases(tests)
+        }
+
+        val coverageVisualisationService = project.service<CoverageVisualisationService>()
+
+        ApplicationManager.getApplication().invokeLater {
+            coverageVisualisationService.showCoverage(testReport)
         }
     }
 }

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -7,7 +7,7 @@ import java.awt.Font
 import javax.swing.JLabel
 import javax.swing.JPanel
 
-class CoverageToolWindowDisplayService(private val project: Project) {
+class CoverageToolWindowDisplayService() {
     var mainPanel: JPanel ?= null
     var panelTitleAbsolute = JLabel("Absolute Test Coverage")
     var panelTitleRelative = JLabel("Relative Test Coverage")
@@ -18,7 +18,7 @@ class CoverageToolWindowDisplayService(private val project: Project) {
     var relativeBranch = JBLabel("Percentage of Branches covered: ")
     var relativeMutant = JBLabel("Percentage of Mutants covered: ")
 
-    var listLabels = listOf<JBLabel>(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
+    private var listLabels = listOf(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
 
 
     /**

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -2,17 +2,15 @@ package com.github.mitchellolsthoorn.testgenie.services
 
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBLabel
-import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.FormBuilder
-import org.jdesktop.swingx.JXTitledSeparator
-import java.awt.BorderLayout
 import java.awt.Font
-import javax.swing.*
+import javax.swing.JLabel
+import javax.swing.JPanel
 
 class CoverageToolWindowDisplayService(private val project: Project) {
     var mainPanel: JPanel ?= null
-    private var panelTitleAbsolute = JLabel("Absolute Test Coverage")
-    private var panelTitleRelative = JLabel("Relative Test Coverage")
+    var panelTitleAbsolute = JLabel("Absolute Test Coverage")
+    var panelTitleRelative = JLabel("Relative Test Coverage")
     var absoluteLines = JBLabel("Amount of Lines covered: " + " Total: ")
     var absoluteBranch = JBLabel("Amount of Branches covered: " + " Total: ")
     var absoluteMutant = JBLabel("Amount of Mutants covered: "  + " Total: ")

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -1,13 +1,12 @@
 package com.github.mitchellolsthoorn.testgenie.services
 
-import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.FormBuilder
 import java.awt.Font
 import javax.swing.JLabel
 import javax.swing.JPanel
 
-class CoverageToolWindowDisplayService() {
+class CoverageToolWindowDisplayService {
     var mainPanel: JPanel ?= null
     var panelTitleAbsolute = JLabel("Absolute Test Coverage")
     var panelTitleRelative = JLabel("Relative Test Coverage")

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -1,0 +1,48 @@
+package com.github.mitchellolsthoorn.testgenie.services
+
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.FormBuilder
+import org.jdesktop.swingx.JXTitledSeparator
+import java.awt.BorderLayout
+import java.awt.Font
+import javax.swing.*
+
+class CoverageToolWindowDisplayService(private val project: Project) {
+    var mainPanel: JPanel ?= null
+    private var panelTitleAbsolute = JLabel("Absolute Test Coverage")
+    private var panelTitleRelative = JLabel("Relative Test Coverage")
+    private var absoluteLines = JBLabel("Amount of Lines covered: " + " Total: ")
+    private var absoluteBranch = JBLabel("Amount of Branches covered: " + " Total: ")
+    private var absoluteMutant = JBLabel("Amount of Mutants covered: "  + " Total: ")
+    private var relativeLines = JBLabel("Percentage of Lines covered: ")
+    private var relativeBranch = JBLabel("Percentage of Branches covered: ")
+    private var relativeMutant = JBLabel("Percentage of Mutants covered: ")
+
+    private var listLabels = listOf<JBLabel>(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
+
+
+
+    init {
+        panelTitleAbsolute.font = Font("Monochrome", Font.BOLD, 20)
+        panelTitleRelative.font = Font("Monochrome", Font.BOLD, 20)
+
+        for (listLabel in listLabels) {
+            listLabel.font = Font("Monochrome", Font.BOLD, 17)
+        }
+        mainPanel = FormBuilder.createFormBuilder()
+                .setFormLeftIndent(30)
+                .addVerticalGap(7)
+                .addComponent(panelTitleAbsolute,25)
+                .addComponent(absoluteLines, 20)
+                .addComponent(absoluteBranch, 20)
+                .addComponent(absoluteMutant, 20)
+                .addComponent(panelTitleRelative, 25)
+                .addComponent(relativeLines, 20)
+                .addComponent(relativeBranch, 20)
+                .addComponent(relativeMutant, 20)
+                .addComponentFillVertically(JPanel(), 20)
+                .panel
+    }
+}

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -23,7 +23,9 @@ class CoverageToolWindowDisplayService(private val project: Project) {
     private var listLabels = listOf<JBLabel>(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
 
 
-
+    /**
+     * Show the labels for statistics on code coverage by tests in "coverage visualisation" tab
+     */
     init {
         panelTitleAbsolute.font = Font("Monochrome", Font.BOLD, 20)
         panelTitleRelative.font = Font("Monochrome", Font.BOLD, 20)

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -13,14 +13,14 @@ class CoverageToolWindowDisplayService(private val project: Project) {
     var mainPanel: JPanel ?= null
     private var panelTitleAbsolute = JLabel("Absolute Test Coverage")
     private var panelTitleRelative = JLabel("Relative Test Coverage")
-    private var absoluteLines = JBLabel("Amount of Lines covered: " + " Total: ")
-    private var absoluteBranch = JBLabel("Amount of Branches covered: " + " Total: ")
-    private var absoluteMutant = JBLabel("Amount of Mutants covered: "  + " Total: ")
-    private var relativeLines = JBLabel("Percentage of Lines covered: ")
-    private var relativeBranch = JBLabel("Percentage of Branches covered: ")
-    private var relativeMutant = JBLabel("Percentage of Mutants covered: ")
+    var absoluteLines = JBLabel("Amount of Lines covered: " + " Total: ")
+    var absoluteBranch = JBLabel("Amount of Branches covered: " + " Total: ")
+    var absoluteMutant = JBLabel("Amount of Mutants covered: "  + " Total: ")
+    var relativeLines = JBLabel("Percentage of Lines covered: ")
+    var relativeBranch = JBLabel("Percentage of Branches covered: ")
+    var relativeMutant = JBLabel("Percentage of Mutants covered: ")
 
-    private var listLabels = listOf<JBLabel>(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
+    var listLabels = listOf<JBLabel>(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
 
 
     /**

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
@@ -20,7 +20,10 @@ class CoverageVisualisationService(private val project: Project) {
      * @param testReport the generated tests summary
      */
     fun showCoverage(testReport: CompactReport) {
-        // Show coverage only if enabled in settings
+        // Show toolWindow statistics
+        fillToolWindowContents(testReport)
+
+        // Show in-line coverage only if enabled in settings
         val state = ApplicationManager.getApplication().getService(TestGenieSettingsService::class.java).state
         if(state.showCoverage) {
             val editor = FileEditorManager.getInstance(project).selectedTextEditor!!
@@ -33,8 +36,6 @@ class CoverageVisualisationService(private val project: Project) {
                 hl.lineMarkerRenderer = TestGenieCoverageRenderer(color, line, testReport.testCaseList
                         .filter { x -> i in x.value.coveredLines }.map{x -> x.key})
             }
-
-            fillToolWindowContents(testReport)
         }
     }
 

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
@@ -1,0 +1,31 @@
+package com.github.mitchellolsthoorn.testgenie.services
+
+import com.github.mitchellolsthoorn.testgenie.coverage.TestGenieCoverageRenderer
+import com.intellij.openapi.diff.DiffColors
+import com.intellij.openapi.editor.markup.HighlighterLayer
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import org.evosuite.utils.CompactReport
+import java.awt.Color
+
+class CoverageVisualisationService(private val project: Project) {
+
+    /**
+     * Shows coverage on the gutter next to the covered lines.
+     *
+     * @param testReport the generated tests summary
+     */
+    fun showCoverage(testReport: CompactReport) {
+            val editor = FileEditorManager.getInstance(project).selectedTextEditor!!
+
+            val color = Color(100, 150, 20)
+
+            for (i in testReport.allCoveredLines) {
+                val line = i - 1
+                val hl = editor.markupModel.addLineHighlighter(DiffColors.DIFF_INSERTED, line, HighlighterLayer.LAST)
+                hl.lineMarkerRenderer = TestGenieCoverageRenderer(color, line, testReport.testCaseList
+                        .filter { x -> i in x.value.coveredLines }.map{x -> x.key})
+            }
+
+    }
+}

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
@@ -1,6 +1,10 @@
 package com.github.mitchellolsthoorn.testgenie.services
 
 import com.github.mitchellolsthoorn.testgenie.coverage.TestGenieCoverageRenderer
+import com.github.mitchellolsthoorn.testgenie.settings.TestGenieSettingsComponent
+import com.github.mitchellolsthoorn.testgenie.settings.TestGenieSettingsService
+import com.github.mitchellolsthoorn.testgenie.settings.TestGenieSettingsState
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diff.DiffColors
 import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -16,6 +20,9 @@ class CoverageVisualisationService(private val project: Project) {
      * @param testReport the generated tests summary
      */
     fun showCoverage(testReport: CompactReport) {
+        // Show coverage only if enabled in settings
+        val state = ApplicationManager.getApplication().getService(TestGenieSettingsService::class.java).state
+        if(state.showCoverage) {
             val editor = FileEditorManager.getInstance(project).selectedTextEditor!!
 
             val color = Color(100, 150, 20)
@@ -26,6 +33,6 @@ class CoverageVisualisationService(private val project: Project) {
                 hl.lineMarkerRenderer = TestGenieCoverageRenderer(color, line, testReport.testCaseList
                         .filter { x -> i in x.value.coveredLines }.map{x -> x.key})
             }
-
+        }
     }
 }

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/services/CoverageVisualisationService.kt
@@ -1,16 +1,16 @@
 package com.github.mitchellolsthoorn.testgenie.services
 
 import com.github.mitchellolsthoorn.testgenie.coverage.TestGenieCoverageRenderer
-import com.github.mitchellolsthoorn.testgenie.settings.TestGenieSettingsComponent
 import com.github.mitchellolsthoorn.testgenie.settings.TestGenieSettingsService
-import com.github.mitchellolsthoorn.testgenie.settings.TestGenieSettingsState
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diff.DiffColors
 import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import org.evosuite.utils.CompactReport
 import java.awt.Color
+import kotlin.math.roundToInt
 
 class CoverageVisualisationService(private val project: Project) {
 
@@ -33,6 +33,52 @@ class CoverageVisualisationService(private val project: Project) {
                 hl.lineMarkerRenderer = TestGenieCoverageRenderer(color, line, testReport.testCaseList
                         .filter { x -> i in x.value.coveredLines }.map{x -> x.key})
             }
+
+            fillToolWindowContents(testReport)
         }
+    }
+
+    /**
+     * Fill the toolWindow to contain the coverage in the labels.
+     *
+     * @param testReport the generated tests summary
+     */
+    private fun fillToolWindowContents(testReport: CompactReport) {
+        val visualisationService = project.service<CoverageToolWindowDisplayService>()
+
+        // Calculate line coverage
+        val coveredLines = testReport.allCoveredLines.size
+        val allLines = testReport.allUncoveredLines.size + coveredLines
+        var relativeLines = 100
+        if (allLines != 0) {
+            relativeLines = (coveredLines.toDouble() / allLines * 100).roundToInt()
+        }
+
+        // Call branch coverage
+        val coveredBranches = testReport.allCoveredBranches.size
+        val allBranches = testReport.allUncoveredBranches.size + coveredBranches
+        var relativeBranch = 100
+        if (allBranches != 0) {
+            relativeBranch = (coveredBranches.toDouble() / allBranches * 100).roundToInt()
+        }
+
+        // Call mutations coverage
+        val coveredMutations = testReport.allCoveredMutation.size
+        val allMutations = testReport.allUncoveredMutation.size + coveredMutations
+        var relativeMutations = 100
+        if (allMutations != 0) {
+            relativeMutations = (coveredMutations.toDouble() / allMutations * 100).roundToInt()
+        }
+
+        visualisationService.panelTitleAbsolute.text = "Absolute Test Coverage for ${testReport.UUT}"
+        visualisationService.panelTitleRelative.text = "Relative Test Coverage for ${testReport.UUT}"
+
+        visualisationService.absoluteLines.text = "Amount of Lines covered: $coveredLines Total: $allLines"
+        visualisationService.absoluteBranch.text = "Amount of Branches covered: $coveredBranches Total: $allBranches"
+        visualisationService.absoluteMutant.text = "Amount of Mutants covered: $coveredMutations Total: $allMutations"
+
+        visualisationService.relativeLines.text = "Percentage of Lines covered: $relativeLines%"
+        visualisationService.relativeBranch.text = "Percentage of Branches covered: $relativeBranch%"
+        visualisationService.relativeMutant.text = "Percentage of Mutants covered: $relativeMutations%"
     }
 }

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/toolwindow/TestGenieToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/toolwindow/TestGenieToolWindowFactory.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentFactory
-import javax.swing.JTextArea
 
 /**
  * This class is responsible for creating the UI of the TestGenie tool window.

--- a/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/toolwindow/TestGenieToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/mitchellolsthoorn/testgenie/toolwindow/TestGenieToolWindowFactory.kt
@@ -1,5 +1,6 @@
 package com.github.mitchellolsthoorn.testgenie.toolwindow
 
+import com.github.mitchellolsthoorn.testgenie.services.CoverageToolWindowDisplayService
 import com.github.mitchellolsthoorn.testgenie.services.TestCaseDisplayService
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -29,10 +30,11 @@ class TestGenieToolWindowFactory : ToolWindowFactory {
 
         val content: Content = contentFactory.createContent(testGeniePanelWrapper.getContent(), "Parameters", false)
 
+        val visualisationService = project.service<CoverageToolWindowDisplayService>()
         toolWindow.contentManager.addContent(content)
         toolWindow.contentManager.addContent(
             contentFactory.createContent(
-                JTextArea("Here is where the coverage visualisation will appear"), "Coverage Visualisation", false
+                visualisationService.mainPanel, "Coverage Visualisation", true
             )
         )
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.github.mitchellolsthoorn.testgenie.services.TestCaseDisplayService"/>
+        <projectService serviceImplementation="com.github.mitchellolsthoorn.testgenie.services.CoverageVisualisationService"/>
 
         <toolWindow id="TestGenie" secondary="true" anchor="right"
                     factoryClass="com.github.mitchellolsthoorn.testgenie.toolwindow.TestGenieToolWindowFactory"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="com.github.mitchellolsthoorn.testgenie.services.TestCaseDisplayService"/>
         <projectService serviceImplementation="com.github.mitchellolsthoorn.testgenie.services.CoverageVisualisationService"/>
+        <projectService serviceImplementation="com.github.mitchellolsthoorn.testgenie.services.CoverageToolWindowDisplayService"/>
 
         <toolWindow id="TestGenie" secondary="true" anchor="right"
                     factoryClass="com.github.mitchellolsthoorn.testgenie.toolwindow.TestGenieToolWindowFactory"/>


### PR DESCRIPTION
# Description of changes made
- Line coverage visualisation.
- In-line coverage visualisation, where it is also visible which tests cover the specific line.
- ToolWindow coverage statistics display.

# Why is merge request needed
Coverage visualisation is one of the features requested by our client. The changes in this pull request can be used to extend the coverage visualisation in the following sprint.

# Other notes
Closes #20


- [x] I have checked that I am merging into correct branch
