### PR TITLE
Coverage visualization

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/coverage/CoverageRenderer.kt
@@ -18,13 +18,13 @@ import java.awt.event.MouseEvent
 
 /**
  * This class extends the line marker and gutter editor to allow more functionality.
- * 
+ *
  * @param color color of marker
  * @param lineNumber lineNumber to color
  * @param tests list of tests that cover this line
  */
-class CoverageRenderer(private val color: Color, private val lineNumber : Int, private val tests : List<String>) : ActiveGutterRenderer,
-    LineMarkerRendererEx {
+class CoverageRenderer(private val color: Color, private val lineNumber: Int, private val tests: List<String>) :
+    ActiveGutterRenderer, LineMarkerRendererEx {
 
     /**
      * Perform the action - show toolTip on mouse click.
@@ -34,11 +34,8 @@ class CoverageRenderer(private val color: Color, private val lineNumber : Int, p
      */
     override fun doAction(editor: Editor, e: MouseEvent) {
         e.consume()
-        val panel = FormBuilder
-            .createFormBuilder()
-            .addComponent(JBLabel(" Covered by tests: $tests "), 10)
-            .addVerticalGap(10)
-            .panel
+        val panel = FormBuilder.createFormBuilder().addComponent(JBLabel(" Covered by tests: $tests "), 10)
+            .addVerticalGap(10).panel
 
         val hint = LightweightHint(panel)
         val point = HintManagerImpl.getHintPosition(hint, editor, LogicalPosition(lineNumber, 0), HintManager.RIGHT)

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/coverage/CoverageRenderer.kt
@@ -23,7 +23,7 @@ import java.awt.event.MouseEvent
  * @param lineNumber lineNumber to color
  * @param tests list of tests that cover this line
  */
-class TestGenieCoverageRenderer(private val color: Color, private val lineNumber : Int, private val tests : List<String>) : ActiveGutterRenderer,
+class CoverageRenderer(private val color: Color, private val lineNumber : Int, private val tests : List<String>) : ActiveGutterRenderer,
     LineMarkerRendererEx {
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -1,26 +1,14 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.services
 
-import com.intellij.ui.components.JBLabel
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.FormBuilder
-import java.awt.Font
-import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.table.AbstractTableModel
 
 class CoverageToolWindowDisplayService {
-    var mainPanel: JPanel ?= null
-    var panelTitleAbsolute = JLabel("Absolute Test Coverage")
-    var panelTitleRelative = JLabel("Relative Test Coverage")
-    var absoluteLines = JBLabel("Amount of Lines covered: " + " Total: ")
-    var absoluteBranch = JBLabel("Amount of Branches covered: " + " Total: ")
-    var absoluteMutant = JBLabel("Amount of Mutants covered: "  + " Total: ")
-    var relativeLines = JBLabel("Percentage of Lines covered: ")
-    var relativeBranch = JBLabel("Percentage of Branches covered: ")
-    var relativeMutant = JBLabel("Percentage of Mutants covered: ")
+    var mainPanel: JPanel? = null
     var data: ArrayList<String> = arrayListOf("Coverage", "Lines", "Branches", "Mutants", "", "", "", "")
 
-    private var listLabels = listOf(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
     // Implementation of abstract table model
     var tableModel = object : AbstractTableModel() {
         /**
@@ -59,24 +47,7 @@ class CoverageToolWindowDisplayService {
      * Show the labels for statistics on code coverage by tests in "coverage visualisation" tab
      */
     init {
-        panelTitleAbsolute.font = Font("Monochrome", Font.BOLD, 20)
-        panelTitleRelative.font = Font("Monochrome", Font.BOLD, 20)
-
-        for (listLabel in listLabels) {
-            listLabel.font = Font("Monochrome", Font.BOLD, 17)
-        }
-        mainPanel = FormBuilder.createFormBuilder()
-                .setFormLeftIndent(30)
-                .addVerticalGap(7)
-                .addComponent(panelTitleAbsolute,25)
-                .addComponent(absoluteLines, 20)
-                .addComponent(absoluteBranch, 20)
-                .addComponent(absoluteMutant, 20)
-                .addComponent(panelTitleRelative, 25)
-                .addComponent(relativeLines, 20)
-                .addComponent(relativeBranch, 20)
-                .addComponent(relativeMutant, 20)
-                .addComponentFillVertically(JPanel(), 20)
-                .panel
+        mainPanel =
+            FormBuilder.createFormBuilder().addComponent(table, 20).addComponentFillVertically(JPanel(), 20).panel
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -7,7 +7,7 @@ import javax.swing.table.AbstractTableModel
 
 class CoverageToolWindowDisplayService {
     var mainPanel: JPanel? = null
-    var data: ArrayList<String> = arrayListOf("Coverage", "Lines", "Branches", "Mutants", "", "", "", "")
+    var data: ArrayList<String> = arrayListOf("", "", "", "")
 
     // Implementation of abstract table model
     private var tableModel = object : AbstractTableModel() {
@@ -17,7 +17,7 @@ class CoverageToolWindowDisplayService {
          * @return row count
          */
         override fun getRowCount(): Int {
-            return 2
+            return 1
         }
 
         /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -1,10 +1,12 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.services
 
 import com.intellij.ui.components.JBLabel
+import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.FormBuilder
 import java.awt.Font
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.table.AbstractTableModel
 
 class CoverageToolWindowDisplayService {
     var mainPanel: JPanel ?= null
@@ -16,9 +18,42 @@ class CoverageToolWindowDisplayService {
     var relativeLines = JBLabel("Percentage of Lines covered: ")
     var relativeBranch = JBLabel("Percentage of Branches covered: ")
     var relativeMutant = JBLabel("Percentage of Mutants covered: ")
+    var data: ArrayList<String> = arrayListOf("Coverage", "Lines", "Branches", "Mutants", "", "", "", "")
 
     private var listLabels = listOf(absoluteLines, absoluteBranch, absoluteMutant, relativeLines, relativeBranch, relativeMutant)
+    // Implementation of abstract table model
+    var tableModel = object : AbstractTableModel() {
+        /**
+         * Returns the number of rows.
+         *
+         * @return row count
+         */
+        override fun getRowCount(): Int {
+            return 2
+        }
 
+        /**
+         * Returns the number of columns.
+         *
+         * @return column count
+         */
+        override fun getColumnCount(): Int {
+            return 4
+        }
+
+        /**
+         * Returns the value at index.
+         *
+         * @param rowIndex index of row
+         * @param columnIndex index of column
+         * @return value at row
+         */
+        override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+            return data[rowIndex * 4 + columnIndex]
+        }
+
+    }
+    var table = JBTable(tableModel)
 
     /**
      * Show the labels for statistics on code coverage by tests in "coverage visualisation" tab

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -10,7 +10,7 @@ class CoverageToolWindowDisplayService {
     var data: ArrayList<String> = arrayListOf("Coverage", "Lines", "Branches", "Mutants", "", "", "", "")
 
     // Implementation of abstract table model
-    var tableModel = object : AbstractTableModel() {
+    private var tableModel = object : AbstractTableModel() {
         /**
          * Returns the number of rows.
          *
@@ -41,7 +41,7 @@ class CoverageToolWindowDisplayService {
         }
 
     }
-    var table = JBTable(tableModel)
+    private var table = JBTable(tableModel)
 
     /**
      * Show the labels for statistics on code coverage by tests in "coverage visualisation" tab

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageToolWindowDisplayService.kt
@@ -1,12 +1,16 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.services
 
+import com.intellij.ui.ScrollPaneFactory
 import com.intellij.ui.table.JBTable
-import com.intellij.util.ui.FormBuilder
-import javax.swing.JPanel
+import java.awt.Dimension
+import javax.swing.JScrollPane
 import javax.swing.table.AbstractTableModel
 
+/**
+ * Class to display EvoSuite coverage in the tool window.
+ */
 class CoverageToolWindowDisplayService {
-    var mainPanel: JPanel? = null
+    var mainPanel: JScrollPane? = null
     var data: ArrayList<String> = arrayListOf("", "", "", "")
 
     // Implementation of abstract table model
@@ -48,6 +52,15 @@ class CoverageToolWindowDisplayService {
      */
     init {
         mainPanel =
-            FormBuilder.createFormBuilder().addComponent(table, 20).addComponentFillVertically(JPanel(), 20).panel
+            ScrollPaneFactory.createScrollPane(table)
+
+        val tableColumnModel = table.columnModel
+        tableColumnModel.getColumn(0).headerValue = "Unit under test"
+        tableColumnModel.getColumn(1).headerValue = "Line coverage"
+        tableColumnModel.getColumn(2).headerValue = "Branch coverage"
+        tableColumnModel.getColumn(3).headerValue = "Weak mutation coverage"
+        table.columnModel = tableColumnModel
+
+        table.minimumSize = Dimension(700, 100)
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -49,7 +49,6 @@ class CoverageVisualisationService(private val project: Project) {
      * @param testReport the generated tests summary
      */
     private fun fillToolWindowContents(testReport: CompactReport) {
-        val visualisationService = project.service<CoverageToolWindowDisplayService>()
 
         // Calculate line coverage
         val coveredLines = testReport.allCoveredLines.size
@@ -76,10 +75,11 @@ class CoverageVisualisationService(private val project: Project) {
         }
 
         // Change the values in the table
-        visualisationService.data[4] = testReport.UUT
-        visualisationService.data[5] = "$relativeLines% ($coveredLines/$allLines)"
-        visualisationService.data[6] = "$relativeBranch% ($coveredBranches/$allBranches)"
-        visualisationService.data[7] = "$relativeMutations% ($coveredMutations/ $allMutations)"
+        val coverageToolWindowDisplayService = project.service<CoverageToolWindowDisplayService>()
+        coverageToolWindowDisplayService.data[4] = testReport.UUT
+        coverageToolWindowDisplayService.data[5] = "$relativeLines% ($coveredLines/$allLines)"
+        coverageToolWindowDisplayService.data[6] = "$relativeBranch% ($coveredBranches/$allBranches)"
+        coverageToolWindowDisplayService.data[7] = "$relativeMutations% ($coveredMutations/ $allMutations)"
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -1,6 +1,6 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.services
 
-import nl.tudelft.ewi.se.ciselab.testgenie.coverage.TestGenieCoverageRenderer
+import nl.tudelft.ewi.se.ciselab.testgenie.coverage.CoverageRenderer
 import nl.tudelft.ewi.se.ciselab.testgenie.settings.TestGenieSettingsService
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
@@ -25,7 +25,7 @@ class CoverageVisualisationService(private val project: Project) {
 
         // Show in-line coverage only if enabled in settings
         val state = ApplicationManager.getApplication().getService(TestGenieSettingsService::class.java).state
-        if(state.showCoverage) {
+        if (state.showCoverage) {
             val editor = FileEditorManager.getInstance(project).selectedTextEditor!!
 
             val color = Color(100, 150, 20)
@@ -33,8 +33,9 @@ class CoverageVisualisationService(private val project: Project) {
             for (i in testReport.allCoveredLines) {
                 val line = i - 1
                 val hl = editor.markupModel.addLineHighlighter(DiffColors.DIFF_INSERTED, line, HighlighterLayer.LAST)
-                hl.lineMarkerRenderer = TestGenieCoverageRenderer(color, line, testReport.testCaseList
-                        .filter { x -> i in x.value.coveredLines }.map{x -> x.key})
+                hl.lineMarkerRenderer = CoverageRenderer(color,
+                    line,
+                    testReport.testCaseList.filter { x -> i in x.value.coveredLines }.map { x -> x.key })
             }
         }
     }
@@ -71,15 +72,12 @@ class CoverageVisualisationService(private val project: Project) {
             relativeMutations = (coveredMutations.toDouble() / allMutations * 100).roundToInt()
         }
 
-        visualisationService.panelTitleAbsolute.text = "Absolute Test Coverage for ${testReport.UUT}"
-        visualisationService.panelTitleRelative.text = "Relative Test Coverage for ${testReport.UUT}"
+        // Change the values in the table
+        visualisationService.data[4] = testReport.UUT
+        visualisationService.data[5] = "$relativeLines% ($coveredLines/$allLines)"
+        visualisationService.data[6] = "$relativeBranch% ($coveredBranches/$allBranches)"
+        visualisationService.data[7] = "$relativeMutations% ($coveredMutations/ $allMutations)"
 
-        visualisationService.absoluteLines.text = "Amount of Lines covered: $coveredLines Total: $allLines"
-        visualisationService.absoluteBranch.text = "Amount of Branches covered: $coveredBranches Total: $allBranches"
-        visualisationService.absoluteMutant.text = "Amount of Mutants covered: $coveredMutations Total: $allMutations"
 
-        visualisationService.relativeLines.text = "Percentage of Lines covered: $relativeLines%"
-        visualisationService.relativeBranch.text = "Percentage of Branches covered: $relativeBranch%"
-        visualisationService.relativeMutant.text = "Percentage of Mutants covered: $relativeMutations%"
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -18,7 +18,7 @@ import kotlin.math.roundToInt
 class CoverageVisualisationService(private val project: Project) {
 
     // Variable to keep reference to the coverage visualisation content
-    var content: Content? = null
+    private var content: Content? = null
 
     /**
      * Shows coverage on the gutter next to the covered lines.

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -15,6 +15,11 @@ import org.evosuite.utils.CompactReport
 import java.awt.Color
 import kotlin.math.roundToInt
 
+/**
+ * Service used to visualise the coverage and inject data in the toolWindow tab.
+ *
+ * @param project the project
+ */
 class CoverageVisualisationService(private val project: Project) {
 
     // Variable to keep reference to the coverage visualisation content
@@ -80,10 +85,10 @@ class CoverageVisualisationService(private val project: Project) {
 
         // Change the values in the table
         val coverageToolWindowDisplayService = project.service<CoverageToolWindowDisplayService>()
-        coverageToolWindowDisplayService.data[4] = testReport.UUT
-        coverageToolWindowDisplayService.data[5] = "$relativeLines% ($coveredLines/$allLines)"
-        coverageToolWindowDisplayService.data[6] = "$relativeBranch% ($coveredBranches/$allBranches)"
-        coverageToolWindowDisplayService.data[7] = "$relativeMutations% ($coveredMutations/ $allMutations)"
+        coverageToolWindowDisplayService.data[0] = testReport.UUT
+        coverageToolWindowDisplayService.data[1] = "$relativeLines% ($coveredLines/$allLines)"
+        coverageToolWindowDisplayService.data[2] = "$relativeBranch% ($coveredBranches/$allBranches)"
+        coverageToolWindowDisplayService.data[3] = "$relativeMutations% ($coveredMutations/ $allMutations)"
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -9,12 +9,16 @@ import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentFactory
 import org.evosuite.utils.CompactReport
 import java.awt.Color
 import kotlin.math.roundToInt
 
 class CoverageVisualisationService(private val project: Project) {
+
+    // Variable to keep reference to the coverage visualisation content
+    var content: Content? = null
 
     /**
      * Shows coverage on the gutter next to the covered lines.
@@ -91,21 +95,19 @@ class CoverageVisualisationService(private val project: Project) {
         // Remove coverage visualisation from content manager if necessary
         val toolWindowManager = ToolWindowManager.getInstance(project).getToolWindow("TestGenie")
         val contentManager = toolWindowManager!!.contentManager
-        for (content in contentManager.contents) {
-            if (content.displayName.equals("Coverage Visualisation")) {
-                contentManager.removeContent(content, true)
-            }
+        if (content != null) {
+            contentManager.removeContent(content!!, true)
         }
 
         // If there is no coverage visualisation tab, make it
         val contentFactory: ContentFactory = ContentFactory.SERVICE.getInstance()
-        val content = contentFactory.createContent(
+        content = contentFactory.createContent(
             visualisationService.mainPanel, "Coverage Visualisation", true
         )
-        contentManager.addContent(content)
+        contentManager.addContent(content!!)
 
         // Focus on coverage tab and open toolWindow if not opened already
-        contentManager.setSelectedContent(content)
+        contentManager.setSelectedContent(content!!)
         toolWindowManager.show()
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/toolwindow/TestGenieToolWindowFactory.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/toolwindow/TestGenieToolWindowFactory.kt
@@ -28,13 +28,6 @@ class TestGenieToolWindowFactory : ToolWindowFactory {
         )
 
         val content: Content = contentFactory.createContent(testGeniePanelWrapper.getContent(), "Parameters", false)
-
-        val visualisationService = project.service<CoverageToolWindowDisplayService>()
         toolWindow.contentManager.addContent(content)
-        toolWindow.contentManager.addContent(
-            contentFactory.createContent(
-                visualisationService.mainPanel, "Coverage Visualisation", true
-            )
-        )
     }
 }


### PR DESCRIPTION
# Description of changes made
- The coverage is now displayed in tabular form instead of a list form.
- The coverage toolWindow tab is opened only when tests are generated.

# Why is merge request needed
The client suggested the changes in issue #11 and we are addressing them here.

# Other notes
Closes #11 

- [x] I have checked that I am merging into correct branch
