### PR TITLE
Hide generated test tab | #64 

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenerationResultListenerImpl.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenerationResultListenerImpl.kt
@@ -18,7 +18,7 @@ class TestGenerationResultListenerImpl(private val project: Project) : TestGener
         val testCaseDisplayService = project.service<TestCaseDisplayService>()
 
         ApplicationManager.getApplication().invokeLater {
-            testCaseDisplayService.displayTestCases(testReport)
+            testCaseDisplayService.showGeneratedTests(testReport)
         }
 
         val coverageVisualisationService = project.service<CoverageVisualisationService>()

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -114,9 +114,5 @@ class CoverageVisualisationService(private val project: Project) {
             visualisationService.mainPanel, "Coverage Visualisation", true
         )
         contentManager.addContent(content!!)
-
-        // Focus on coverage tab and open toolWindow if not opened already
-        contentManager.setSelectedContent(content!!)
-        toolWindowManager.show()
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -38,6 +38,11 @@ class TestCaseDisplayService(private val project: Project) {
         mainPanel.add(scrollPane, BorderLayout.CENTER)
     }
 
+    fun showGeneratedTests(testReport: CompactReport) {
+        displayTestCases(testReport)
+        createToolWindowTab()
+    }
+
     /**
      * Fill the panel with the generated test cases. Remove all previously shown test cases.
      * Add Tests and their names to a List of pairs (used for highlighting)

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/toolwindow/TestGenieToolWindowFactory.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/toolwindow/TestGenieToolWindowFactory.kt
@@ -1,12 +1,10 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.toolwindow
 
-import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentFactory
-import nl.tudelft.ewi.se.ciselab.testgenie.services.TestCaseDisplayService
 
 /**
  * This class is responsible for creating the UI of the TestGenie tool window.
@@ -18,14 +16,6 @@ class TestGenieToolWindowFactory : ToolWindowFactory {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val quickAccessParameters = QuickAccessParameters(project)
         val contentFactory: ContentFactory = ContentFactory.SERVICE.getInstance()
-
-        val testCaseDisplayService = project.service<TestCaseDisplayService>()
-        toolWindow.contentManager.addContent(
-            contentFactory.createContent(
-                testCaseDisplayService.mainPanel, "Generated Tests", true
-            )
-        )
-
         val content: Content = contentFactory.createContent(quickAccessParameters.getContent(), "Parameters", false)
         toolWindow.contentManager.addContent(content)
     }


### PR DESCRIPTION
# Description of changes made
Look in the commits for a detailed overview of each change. 
Files modified: 
- TestGenieToolWindowFactory.kt
    -  Remove Generated Tests tab from ToolWindow when the ToolWindow is first opened. Now there will only be parameters tab. 
    
- TestCaseDisplayService.kt
    - Add createToolWindowTab() to TestCaseDisplayService. 
    - Add showGeneratedTests() to TestCaseDisplayService.
    
- CoverageVisualisationService.kt
    - Remove focus from Coverage Visualisation tab in tool window. 
    
- TestGenerationResultListenerImpl.kt
    - Use showGeneratedTest() to create a tab in tool window once the tests were generated. 


# Why is merge request needed
This merge is need to fulfill issue #64. Specifically, it will clean up the sidebar tool window by removing the "Generated Tests" tab from it, since in the start this tab is empty because there are no generated tests. Furthermore, this tab will only appear once the Tests are generated. 

# Other notes
Closes #64


# What is missing?
I think that nothing is missing at this point for this issue. Everything should work.

- [X] I have checked that I am merging into correct branch
