### PR TITLE
Apply tests to test class

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -22,7 +22,7 @@ class TestCaseDisplayService(private val project: Project) {
     private val applyButton: JButton = JButton("Apply")
     private val allTestCasePanel: JPanel = JPanel()
     private val scrollPane: JBScrollPane = JBScrollPane(allTestCasePanel)
-    private var testCasePanels: HashMap<String, EditorTextField> = HashMap()
+    private var testCasePanels: HashMap<String, JPanel> = HashMap()
     private val highlightColor: Color = Color(100, 150, 20, 30)
 
     init {
@@ -55,7 +55,6 @@ class TestCaseDisplayService(private val project: Project) {
                 .createExpressionCodeFragment(testCode, null, null, true)
             val document = PsiDocumentManager.getInstance(project).getDocument(code)
             val editor = EditorTextField(document, project, JavaFileType.INSTANCE)
-            testCasePanels[testName] = editor
 
             editor.setOneLineMode(false)
             editor.isViewer = true
@@ -64,6 +63,7 @@ class TestCaseDisplayService(private val project: Project) {
 
             testCasePanel.maximumSize = Dimension(Short.MAX_VALUE.toInt(), Short.MAX_VALUE.toInt())
             allTestCasePanel.add(testCasePanel)
+            testCasePanels[testName] = testCasePanel
             allTestCasePanel.add(Box.createRigidArea(Dimension(0, 5)))
         }
     }
@@ -74,7 +74,7 @@ class TestCaseDisplayService(private val project: Project) {
      * @param name name of the test whose editor should be highlighted
      */
     fun highlight(name: String) {
-        val editor = testCasePanels[name]!!
+        val editor = testCasePanels[name]!!.getComponent(1) as EditorTextField
         val backgroundDefault = editor.background
         editor.background = highlightColor
         Thread {

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -22,7 +22,7 @@ class TestCaseDisplayService(private val project: Project) {
     private val applyButton: JButton = JButton("Apply")
     private val allTestCasePanel: JPanel = JPanel()
     private val scrollPane: JBScrollPane = JBScrollPane(allTestCasePanel)
-    private var editorList: MutableList<Pair<String, EditorTextField>> = arrayListOf()
+    private var testCasePanels: HashMap<String, EditorTextField> = HashMap()
     private val highlightColor: Color = Color(100, 150, 20, 30)
 
     init {
@@ -40,7 +40,7 @@ class TestCaseDisplayService(private val project: Project) {
      */
     fun displayTestCases(testReport: CompactReport) {
         allTestCasePanel.removeAll()
-        editorList = arrayListOf()
+        testCasePanels.clear()
         testReport.testCaseList.values.forEach {
             val testCode = it.testCode
             val testName = it.testName
@@ -55,7 +55,7 @@ class TestCaseDisplayService(private val project: Project) {
                 .createExpressionCodeFragment(testCode, null, null, true)
             val document = PsiDocumentManager.getInstance(project).getDocument(code)
             val editor = EditorTextField(document, project, JavaFileType.INSTANCE)
-            editorList.add(Pair(testName, editor))
+            testCasePanels[testName] = editor
 
             editor.setOneLineMode(false)
             editor.isViewer = true
@@ -74,18 +74,12 @@ class TestCaseDisplayService(private val project: Project) {
      * @param name name of the test whose editor should be highlighted
      */
     fun highlight(name: String) {
-        for (i in editorList) {
-            val testCase = i.first
-            if (testCase == name) {
-                val editor = i.second
-                val backgroundDefault = editor.background
-                editor.background = highlightColor
-                Thread {
-                    Thread.sleep(10000)
-                    editor.background = backgroundDefault
-                }.start()
-                return
-            }
-        }
+        val editor = testCasePanels[name]!!
+        val backgroundDefault = editor.background
+        editor.background = highlightColor
+        Thread {
+            Thread.sleep(10000)
+            editor.background = backgroundDefault
+        }.start()
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -87,7 +87,6 @@ class TestCaseDisplayService(private val project: Project) {
         }.start()
     }
 
-
     /**
      * Show a dialog where the user can select what test class the tests should be applied to,
      * and apply the selected tests to the test class.
@@ -95,7 +94,6 @@ class TestCaseDisplayService(private val project: Project) {
     private fun applyTests() {
         val selectedTestCases = testCasePanels.filter { (it.value.getComponent(0) as JCheckBox).isSelected }
             .map { it.key }
-
 
         val testCaseComponents = selectedTestCases.map {
             testCasePanels[it]!!.getComponent(1) as EditorTextField

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -3,22 +3,16 @@ package nl.tudelft.ewi.se.ciselab.testgenie.services
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.ide.util.TreeClassChooserFactory
 import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.fileChooser.FileChooserDescriptor
-import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.project.Project
-import com.intellij.psi.*
-import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.JavaCodeFragmentFactory
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.ui.EditorTextField
 import com.intellij.ui.components.JBScrollPane
 import org.evosuite.utils.CompactReport
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
-import javax.swing.Box
-import javax.swing.BoxLayout
-import javax.swing.JButton
-import javax.swing.JCheckBox
-import javax.swing.JPanel
+import javax.swing.*
 
 class TestCaseDisplayService(private val project: Project) {
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -2,8 +2,7 @@ package nl.tudelft.ewi.se.ciselab.testgenie.services
 
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.openapi.project.Project
-import com.intellij.psi.JavaCodeFragmentFactory
-import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.*
 import com.intellij.ui.EditorTextField
 import com.intellij.ui.components.JBScrollPane
 import org.evosuite.utils.CompactReport
@@ -28,6 +27,7 @@ class TestCaseDisplayService(private val project: Project) {
     init {
         allTestCasePanel.layout = BoxLayout(allTestCasePanel, BoxLayout.Y_AXIS)
         mainPanel.layout = BorderLayout()
+        applyButton.addActionListener { applyTests() }
         mainPanel.add(applyButton, BorderLayout.SOUTH)
         mainPanel.add(scrollPane, BorderLayout.CENTER)
     }
@@ -81,5 +81,37 @@ class TestCaseDisplayService(private val project: Project) {
             Thread.sleep(10000)
             editor.background = backgroundDefault
         }.start()
+    }
+
+    private fun applyTests() {
+        val selectedTestCases = testCasePanels.filter { (it.value.getComponent(0) as JCheckBox).isSelected }
+            .map { it.key }
+
+
+        val testCaseComponents = selectedTestCases.map {
+            testCasePanels[it]!!.getComponent(1) as EditorTextField
+        }.map {
+//            val code = it.document.text
+//            JavaCodeFragmentFactory.getInstance(project)
+//                .createExpressionCodeFragment(code, null, null, true)
+            it.document.text
+        }
+
+        println(testCaseComponents)
+
+//        val testSuiteFile = PsiFileFactory.getInstance(project)
+//            .createFileFromText("test_suite.java", JavaFileType.INSTANCE, testSuiteClass) as PsiJavaFile
+//        val testSuiteFileDirectory = testSuiteFile.containingDirectory
+//        val testSuiteFileDirectoryVirtualFile = testSuiteFileDirectory.virtualFile
+//        val testSuiteFileDirectoryPsiDirectory =
+//            PsiManager.getInstance(project).findDirectory(testSuiteFileDirectoryVirtualFile)!!
+//        val testSuiteFilePsiDirectory = testSuiteFileDirectoryPsiDirectory.findSubdirectory("test")!!
+//        val testSuiteFilePsiFile = testSuiteFilePsiDirectory.findFile("TestSuite.java")!!
+//        val testSuiteFilePsiFileVirtualFile = testSuiteFilePsiFile.virtualFile
+//        val testSuiteFilePsiFilePsiFile = PsiManager.getInstance(project).findFile(testSuiteFilePsiFileVirtualFile)!!
+//        val testSuiteFilePsiFilePsiDirectory = testSuiteFilePsiFilePsiFile.parent!!
+//        val testSuiteFilePsiFilePsiFileDirectoryVirtualFile = testSuiteFilePsiFilePsiDirectory.virtualFile
+//        val testSuiteFilePsiFilePsiFileDirectoryPsiDirectory =
+//            PsiManager.getInstance(project).findDirectory(testSuiteFilePsiFilePsiDirectory.virtualFile)!!
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -1,8 +1,13 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.services
 
 import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.ide.util.TreeClassChooserFactory
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.ui.EditorTextField
 import com.intellij.ui.components.JBScrollPane
 import org.evosuite.utils.CompactReport
@@ -91,27 +96,27 @@ class TestCaseDisplayService(private val project: Project) {
         val testCaseComponents = selectedTestCases.map {
             testCasePanels[it]!!.getComponent(1) as EditorTextField
         }.map {
-//            val code = it.document.text
-//            JavaCodeFragmentFactory.getInstance(project)
-//                .createExpressionCodeFragment(code, null, null, true)
-            it.document.text
+            val code = it.document.text
+            JavaCodeFragmentFactory.getInstance(project)
+                .createExpressionCodeFragment(code, null, null, true)
         }
 
-        println(testCaseComponents)
 
-//        val testSuiteFile = PsiFileFactory.getInstance(project)
-//            .createFileFromText("test_suite.java", JavaFileType.INSTANCE, testSuiteClass) as PsiJavaFile
-//        val testSuiteFileDirectory = testSuiteFile.containingDirectory
-//        val testSuiteFileDirectoryVirtualFile = testSuiteFileDirectory.virtualFile
-//        val testSuiteFileDirectoryPsiDirectory =
-//            PsiManager.getInstance(project).findDirectory(testSuiteFileDirectoryVirtualFile)!!
-//        val testSuiteFilePsiDirectory = testSuiteFileDirectoryPsiDirectory.findSubdirectory("test")!!
-//        val testSuiteFilePsiFile = testSuiteFilePsiDirectory.findFile("TestSuite.java")!!
-//        val testSuiteFilePsiFileVirtualFile = testSuiteFilePsiFile.virtualFile
-//        val testSuiteFilePsiFilePsiFile = PsiManager.getInstance(project).findFile(testSuiteFilePsiFileVirtualFile)!!
-//        val testSuiteFilePsiFilePsiDirectory = testSuiteFilePsiFilePsiFile.parent!!
-//        val testSuiteFilePsiFilePsiFileDirectoryVirtualFile = testSuiteFilePsiFilePsiDirectory.virtualFile
-//        val testSuiteFilePsiFilePsiFileDirectoryPsiDirectory =
-//            PsiManager.getInstance(project).findDirectory(testSuiteFilePsiFilePsiDirectory.virtualFile)!!
+        // show chooser dialog to select test file
+        val chooser = TreeClassChooserFactory.getInstance(project)
+            .createProjectScopeChooser(
+                "Insert Test Cases into Class"
+            )
+        chooser.showDialog()
+
+        // get selected class or return if no class was selected
+        val selectedClass = chooser.selected ?: return
+
+        // insert test case components into selected class
+        WriteCommandAction.runWriteCommandAction(project) {
+            testCaseComponents.forEach {
+                selectedClass.addBefore(it, selectedClass.rBrace)
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description of changes made
Allow the user to pick a test class to apply the selected tests to, and append the chosen test cases to the end of that class

# Why is merge request needed
Applying the test cases generated via TestGenie is a very nice feature so that the user doesn't have to copy them manually.

# Other notes
Closes #45 
