### PR TITLE
Allow test cases to be edited in the tool window

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -72,7 +72,6 @@ class TestCaseDisplayService(private val project: Project) {
             editorList.add(Pair(testName, editor))
 
             editor.setOneLineMode(false)
-            editor.isViewer = true
 
             testCasePanel.add(editor, BorderLayout.CENTER)
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -141,7 +141,8 @@ class TestCaseDisplayService(private val project: Project) {
                     .getDocument(selectedClass.containingFile)!!
                     .insertString(
                         selectedClass.rBrace!!.textRange.startOffset,
-                        it
+                        // Fix Windows line separators
+                        it.replace("\r\n", "\n")
                     )
             }
         }


### PR DESCRIPTION
# Description of changes made
Make the fields in the tool window editable so that the user can modify the test cases before applying them.

# Why is merge request needed
Feature was requested by the client.

# Other notes
Closes #79 

# What is missing?
There is no autocompletion as the editor fields are not assigned a context.

False syntax errors are shown (fixed in #83)
