### PR TITLE
Fix bug where selecting external classes when applying tests is possible

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -122,6 +122,17 @@ class TestCaseDisplayService(private val project: Project) {
             .createProjectScopeChooser(
                 "Insert Test Cases into Class"
             )
+
+        // Warning: The following code is extremely cursed.
+        // It is a workaround for an oversight in the IntelliJ TreeJavaClassChooserDialog.
+        // This is necessary in order to set isShowLibraryContents to false in
+        // the AbstractTreeClassChooserDialog (parent of the TreeJavaClassChooserDialog).
+        // If this is not done, the user can pick a non-project class (e.g. a class from a library).
+        // See https://github.com/ciselab/TestGenie/issues/102
+        val showLibraryContentsField = chooser.javaClass.superclass.getDeclaredField("myIsShowLibraryContents")
+        showLibraryContentsField.isAccessible = true
+        showLibraryContentsField.set(chooser, false)
+
         chooser.showDialog()
 
         // get selected class or return if no class was selected


### PR DESCRIPTION
# Description of changes made
When applying tests, it was possible to apply them to a class that's not part of the project, which is not intended.

# Why is merge request needed
This PR fixes the aforementioned bug.

# Other notes
Closes #102

The fix is quite sketchy but there seems to be no other way to disable this behaviour. This is a workaround for an oversight in the IntelliJ TreeJavaClassChooserDialog.
