### PR TITLE
Add an option to select individual lines for test generation

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
@@ -14,7 +14,7 @@ import com.intellij.psi.PsiFile
  */
 class GenerateTestsActionClass : AnAction() {
     /**
-     * Performs test generation for a class when the action is invoked.
+     * Creates and calls (EvoSuite) Runner to generate tests for a class when the action is invoked.
      *
      * @param e an action event that contains useful information
      */

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
@@ -16,7 +16,7 @@ class GenerateTestsActionClass : AnAction() {
     /**
      * Creates and calls (EvoSuite) Runner to generate tests for a class when the action is invoked.
      *
-     * @param e an action event that contains useful information
+     * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun actionPerformed(e: AnActionEvent) {
         createEvoSuiteRunner(e)?.forClass()?.runEvoSuite()
@@ -26,7 +26,7 @@ class GenerateTestsActionClass : AnAction() {
      * Makes the action visible only if a class has been selected.
      * It also updates the action name depending on which class has been selected.
      *
-     * @param e an action event that contains useful information
+     * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
@@ -3,13 +3,9 @@ package nl.tudelft.ewi.se.ciselab.testgenie.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
-import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
 
 /**
  * This class contains all the logic related to generating tests for a class.
@@ -17,33 +13,12 @@ import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
  *   getting the information about the selected class and passing it to (EvoSuite) Runner.
  */
 class GenerateTestsActionClass : AnAction() {
-    private val log = Logger.getInstance(this.javaClass)
-
     /**
      * Performs test generation for a class when the action is invoked.
      *
      * @param e an action event that contains useful information
      */
     override fun actionPerformed(e: AnActionEvent) {
-//        val project: Project = e.project ?: return
-//
-//        val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
-//        val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
-//        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-//        val fileName = vFile.presentableUrl
-//        val modificationStamp = vFile.modificationStamp
-//
-//        val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
-//        val classFQN = psiClass.qualifiedName ?: return
-//
-//        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
-//        val projectClassPath = "$projectPath/target/classes/"
-//
-//        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
-//
-//        log.info("Selected class is $classFQN")
-
-//        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forClass().runEvoSuite()
         createEvoSuiteRunner(e)?.forClass()?.runEvoSuite()
     }
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
@@ -25,25 +25,26 @@ class GenerateTestsActionClass : AnAction() {
      * @param e an action event that contains useful information
      */
     override fun actionPerformed(e: AnActionEvent) {
-        val project: Project = e.project ?: return
+//        val project: Project = e.project ?: return
+//
+//        val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
+//        val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
+//        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+//        val fileName = vFile.presentableUrl
+//        val modificationStamp = vFile.modificationStamp
+//
+//        val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
+//        val classFQN = psiClass.qualifiedName ?: return
+//
+//        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
+//        val projectClassPath = "$projectPath/target/classes/"
+//
+//        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
+//
+//        log.info("Selected class is $classFQN")
 
-        val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
-        val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
-        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-        val fileName = vFile.presentableUrl
-        val modificationStamp = vFile.modificationStamp
-
-        val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
-        val classFQN = psiClass.qualifiedName ?: return
-
-        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
-        val projectClassPath = "$projectPath/target/classes/"
-
-        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
-
-        log.info("Selected class is $classFQN")
-
-        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forClass().runEvoSuite()
+//        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forClass().runEvoSuite()
+        createEvoSuiteRunner(e)?.forClass()?.runEvoSuite()
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -14,6 +14,8 @@ import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
  *   getting the information about the selected class and passing it to (EvoSuite) Runner.
  */
 class GenerateTestsActionLine : AnAction() {
+    private val logger: Logger = Logger.getInstance(this.javaClass)
+
     /**
      * Creates and calls (EvoSuite) Runner to generate tests for a line when the action is invoked.
      *
@@ -28,7 +30,7 @@ class GenerateTestsActionLine : AnAction() {
         val selectedLine: Int = getSurroundingLine(psiFile, caret)?.plus(1)
             ?: return // lines in the editor and in EvoSuite are one-based
 
-        Logger.getInstance("GenerateTestsUtils").info("Selected line is $selectedLine")
+        logger.info("Selected line is $selectedLine")
 
         evoSuiteRunner.forLine(selectedLine).runEvoSuite()
     }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -5,9 +5,9 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.ui.Messages
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethod
 
 class GenerateTestsActionLine : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -27,15 +27,11 @@ class GenerateTestsActionLine : AnAction() {
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
 
-        getSurroundingMethod(psiFile, caret) ?: return
+        val psiMethod: PsiMethod = getSurroundingMethod(psiFile, caret) ?: return
         val doc: Document = PsiDocumentManager.getInstance(e.project!!).getDocument(psiFile) ?: return
         val line: Int? = getSurroundingLine(doc, caret)
-        println(line)
-        // TODO Ignore declarations
-        return
-        Messages.showInfoMessage("Selected line: $line\nSelected text:\n$", "la")
 
-        e.presentation.isEnabledAndVisible = true
-//        e.presentation.text = "Generate Tests For ${getMethodDisplayName(psiMethod)}"
+        e.presentation.isEnabledAndVisible = validateLine(line!!, psiMethod, doc)
+        e.presentation.text = "Generate Tests For ${getMethodDisplayName(psiMethod)}"
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -2,8 +2,40 @@ package nl.tudelft.ewi.se.ciselab.testgenie.actions
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.ui.Messages
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
 
 class GenerateTestsActionLine : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
+    }
+
+    /**
+     * Makes the action visible only if a line has been selected.
+     * It also updates the action name depending on which line has been selected.
+     *
+     * @param e an action event that contains useful information
+     */
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = false
+
+        e.project ?: return
+
+        val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
+        val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
+
+        getSurroundingMethod(psiFile, caret) ?: return
+        val doc: Document = PsiDocumentManager.getInstance(e.project!!).getDocument(psiFile) ?: return
+        val line: Int? = getSurroundingLine(doc, caret)
+        println(line)
+        // TODO Ignore declarations
+        return
+        Messages.showInfoMessage("Selected line: $line\nSelected text:\n$", "la")
+
+        e.presentation.isEnabledAndVisible = true
+//        e.presentation.text = "Generate Tests For ${getMethodDisplayName(psiMethod)}"
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -15,7 +15,7 @@ import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
  */
 class GenerateTestsActionLine : AnAction() {
     /**
-     * Performs test generation for a line when the action is invoked.
+     * Creates and calls (EvoSuite) Runner to generate tests for a line when the action is invoked.
      *
      * @param e an action event that contains useful information
      */

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -4,10 +4,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.editor.Document
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiMethod
 
 class GenerateTestsActionLine : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -22,17 +19,12 @@ class GenerateTestsActionLine : AnAction() {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = false
 
-        e.project ?: return
-
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
 
-        val psiMethod: PsiMethod = getSurroundingMethod(psiFile, caret) ?: return
-        val doc: Document = PsiDocumentManager.getInstance(e.project!!).getDocument(psiFile) ?: return
-        // val line: Int? = getSurroundingLine(doc, caret)
+        val line: Int = getSurroundingLine(psiFile, caret) ?: return
 
-        val lineValid = validateLine(caret.caretModel.primaryCaret.offset, psiMethod, doc)
-        e.presentation.isEnabledAndVisible = lineValid
-        e.presentation.text = "Generate Tests For ${getMethodDisplayName(psiMethod)}"
+        e.presentation.isEnabledAndVisible = true
+        e.presentation.text = "Generate Tests For $line"
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
+import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
 
 /**
  * This class contains all the logic related to generating tests for a line.
@@ -28,11 +29,14 @@ class GenerateTestsActionLine : AnAction() {
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
+        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val fileName = vFile.presentableUrl
+        val modificationStamp = vFile.modificationStamp
 
         val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
         val classFQN = psiClass.qualifiedName ?: return
 
-        val line: Int = getSurroundingLine(psiFile, caret) ?: return
+        val selectedLine: Int = getSurroundingLine(psiFile, caret) ?: return
 
         val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
         val projectClassPath = "$projectPath/target/classes/"
@@ -40,9 +44,9 @@ class GenerateTestsActionLine : AnAction() {
         log.info("Generating tests for project $projectPath with classpath $projectClassPath")
 
         log.info("Selected class is $classFQN")
-        log.info("Selected line is $line")
+        log.info("Selected line is $selectedLine")
 
-        // Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forClass().runEvoSuite()
+        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forLine(selectedLine).runEvoSuite()
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -29,14 +29,14 @@ class GenerateTestsActionLine : AnAction() {
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
-        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-        val fileName = vFile.presentableUrl
-        val modificationStamp = vFile.modificationStamp
 
         val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
         val classFQN = psiClass.qualifiedName ?: return
 
         val selectedLine: Int = getSurroundingLine(psiFile, caret) ?: return
+        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val fileName = vFile.presentableUrl
+        val modificationStamp = vFile.modificationStamp
 
         val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
         val projectClassPath = "$projectPath/target/classes/"
@@ -46,7 +46,8 @@ class GenerateTestsActionLine : AnAction() {
         log.info("Selected class is $classFQN")
         log.info("Selected line is $selectedLine")
 
-        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forLine(selectedLine).runEvoSuite()
+        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forLine(selectedLine)
+            .runEvoSuite()
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -33,7 +33,7 @@ class GenerateTestsActionLine : AnAction() {
         val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
         val classFQN = psiClass.qualifiedName ?: return
 
-        val selectedLine: Int = getSurroundingLine(psiFile, caret) ?: return
+        val selectedLine: Int = getSurroundingLine(psiFile, caret)?.plus(1) ?: return // lines in the editor and in EvoSuite are one-based
         val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
         val fileName = vFile.presentableUrl
         val modificationStamp = vFile.modificationStamp
@@ -62,9 +62,9 @@ class GenerateTestsActionLine : AnAction() {
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
 
-        val line: Int = getSurroundingLine(psiFile, caret) ?: return
+        val line: Int = getSurroundingLine(psiFile, caret)?.plus(1) ?: return // lines in the editor and in EvoSuite are one-based
 
         e.presentation.isEnabledAndVisible = true
-        e.presentation.text = "Generate Tests For Line ${line + 1}"
+        e.presentation.text = "Generate Tests For Line $line"
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -5,9 +5,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
 import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
 
@@ -25,29 +22,33 @@ class GenerateTestsActionLine : AnAction() {
      * @param e an action event that contains useful information
      */
     override fun actionPerformed(e: AnActionEvent) {
-        val project: Project = e.project ?: return
+//        val project: Project = e.project ?: return
+
+        val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
 
-        val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
-        val classFQN = psiClass.qualifiedName ?: return
+//        val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
+//        val classFQN = psiClass.qualifiedName ?: return
 
         val selectedLine: Int = getSurroundingLine(psiFile, caret)?.plus(1) ?: return // lines in the editor and in EvoSuite are one-based
-        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-        val fileName = vFile.presentableUrl
-        val modificationStamp = vFile.modificationStamp
+//        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+//        val fileName = vFile.presentableUrl
+//        val modificationStamp = vFile.modificationStamp
 
-        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
-        val projectClassPath = "$projectPath/target/classes/"
+//        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
+//        val projectClassPath = "$projectPath/target/classes/"
 
-        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
+//        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
 
-        log.info("Selected class is $classFQN")
-        log.info("Selected line is $selectedLine")
+//        log.info("Selected class is $classFQN")
 
-        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forLine(selectedLine)
-            .runEvoSuite()
+        Logger.getInstance("Test Generation").info("Selected line is $selectedLine")
+
+//        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forLine(selectedLine)
+//            .runEvoSuite()
+        evoSuiteRunner.forLine(selectedLine).runEvoSuite()
     }
 
     /**
@@ -62,7 +63,8 @@ class GenerateTestsActionLine : AnAction() {
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
 
-        val line: Int = getSurroundingLine(psiFile, caret)?.plus(1) ?: return // lines in the editor and in EvoSuite are one-based
+        val line: Int = getSurroundingLine(psiFile, caret)?.plus(1)
+            ?: return // lines in the editor and in EvoSuite are one-based
 
         e.presentation.isEnabledAndVisible = true
         e.presentation.text = "Generate Tests For Line $line"

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -17,7 +17,7 @@ class GenerateTestsActionLine : AnAction() {
     /**
      * Creates and calls (EvoSuite) Runner to generate tests for a line when the action is invoked.
      *
-     * @param e an action event that contains useful information
+     * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun actionPerformed(e: AnActionEvent) {
         val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
@@ -37,7 +37,7 @@ class GenerateTestsActionLine : AnAction() {
      * Makes the action visible only if a line has been selected.
      * It also updates the action name depending on which line has been selected.
      *
-     * @param e an action event that contains useful information
+     * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -29,9 +29,10 @@ class GenerateTestsActionLine : AnAction() {
 
         val psiMethod: PsiMethod = getSurroundingMethod(psiFile, caret) ?: return
         val doc: Document = PsiDocumentManager.getInstance(e.project!!).getDocument(psiFile) ?: return
-        val line: Int? = getSurroundingLine(doc, caret)
+        // val line: Int? = getSurroundingLine(doc, caret)
 
-        e.presentation.isEnabledAndVisible = validateLine(line!!, psiMethod, doc)
+        val lineValid = validateLine(caret.caretModel.primaryCaret.offset, psiMethod, doc)
+        e.presentation.isEnabledAndVisible = lineValid
         e.presentation.text = "Generate Tests For ${getMethodDisplayName(psiMethod)}"
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -3,11 +3,46 @@ package nl.tudelft.ewi.se.ciselab.testgenie.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
 
+/**
+ * This class contains all the logic related to generating tests for a line.
+ * No actual generation happens in this class, rather it is responsible for displaying the action option to the user when it is available,
+ *   getting the information about the selected class and passing it to (EvoSuite) Runner.
+ */
 class GenerateTestsActionLine : AnAction() {
+    private val log = Logger.getInstance(this.javaClass)
+
+    /**
+     * Performs test generation for a line when the action is invoked.
+     *
+     * @param e an action event that contains useful information
+     */
     override fun actionPerformed(e: AnActionEvent) {
+        val project: Project = e.project ?: return
+
+        val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
+        val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
+
+        val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
+        val classFQN = psiClass.qualifiedName ?: return
+
+        val line: Int = getSurroundingLine(psiFile, caret) ?: return
+
+        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
+        val projectClassPath = "$projectPath/target/classes/"
+
+        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
+
+        log.info("Selected class is $classFQN")
+        log.info("Selected line is $line")
+
+        // Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forClass().runEvoSuite()
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -14,40 +14,22 @@ import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
  *   getting the information about the selected class and passing it to (EvoSuite) Runner.
  */
 class GenerateTestsActionLine : AnAction() {
-    private val log = Logger.getInstance(this.javaClass)
-
     /**
      * Performs test generation for a line when the action is invoked.
      *
      * @param e an action event that contains useful information
      */
     override fun actionPerformed(e: AnActionEvent) {
-//        val project: Project = e.project ?: return
-
         val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
 
-//        val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
-//        val classFQN = psiClass.qualifiedName ?: return
+        val selectedLine: Int = getSurroundingLine(psiFile, caret)?.plus(1)
+            ?: return // lines in the editor and in EvoSuite are one-based
 
-        val selectedLine: Int = getSurroundingLine(psiFile, caret)?.plus(1) ?: return // lines in the editor and in EvoSuite are one-based
-//        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-//        val fileName = vFile.presentableUrl
-//        val modificationStamp = vFile.modificationStamp
+        Logger.getInstance("GenerateTestsUtils").info("Selected line is $selectedLine")
 
-//        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
-//        val projectClassPath = "$projectPath/target/classes/"
-
-//        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
-
-//        log.info("Selected class is $classFQN")
-
-        Logger.getInstance("Test Generation").info("Selected line is $selectedLine")
-
-//        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forLine(selectedLine)
-//            .runEvoSuite()
         evoSuiteRunner.forLine(selectedLine).runEvoSuite()
     }
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -1,0 +1,9 @@
+package nl.tudelft.ewi.se.ciselab.testgenie.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class GenerateTestsActionLine : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+    }
+}

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -60,6 +60,6 @@ class GenerateTestsActionLine : AnAction() {
         val line: Int = getSurroundingLine(psiFile, caret) ?: return
 
         e.presentation.isEnabledAndVisible = true
-        e.presentation.text = "Generate Tests For $line"
+        e.presentation.text = "Generate Tests For Line ${line + 1}"
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
@@ -5,9 +5,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
 import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
@@ -27,35 +24,30 @@ class GenerateTestsActionMethod : AnAction() {
      * @param e an action event that contains useful information
      */
     override fun actionPerformed(e: AnActionEvent) {
-        val project: Project = e.project ?: return
+//        val project: Project = e.project ?: return
+
+        val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
-        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-        val fileName = vFile.presentableUrl
-        val modificationStamp = vFile.modificationStamp
+//        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+//        val fileName = vFile.presentableUrl
+//        val modificationStamp = vFile.modificationStamp
 
         val psiMethod: PsiMethod = getSurroundingMethod(psiFile, caret) ?: return
-        val containingClass: PsiClass = psiMethod.containingClass ?: return
+//        val containingClass: PsiClass = psiMethod.containingClass ?: return
 
-        val classFQN = containingClass.qualifiedName ?: return
+//        val classFQN = containingClass.qualifiedName ?: return
         val methodDescriptor = generateMethodDescriptor(psiMethod)
 
-        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
-        val projectClassPath = "$projectPath/target/classes/"
+//        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
+//        val projectClassPath = "$projectPath/target/classes/"
+//
+//        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
 
-        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
+        Logger.getInstance("Test Generation").info("Selected method is $methodDescriptor")
 
-        log.info("Selected class is $classFQN, method is $methodDescriptor")
-
-        Runner(
-            project,
-            projectPath,
-            projectClassPath,
-            classFQN,
-            fileName,
-            modificationStamp
-        ).forMethod(methodDescriptor).runEvoSuite()
+        evoSuiteRunner.forMethod(methodDescriptor).runEvoSuite()
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
@@ -16,36 +16,21 @@ import nl.tudelft.ewi.se.ciselab.testgenie.helpers.generateMethodDescriptor
  *   getting the information about the selected method and passing it to (EvoSuite) Runner.
  */
 class GenerateTestsActionMethod : AnAction() {
-    private val log = Logger.getInstance(this.javaClass)
-
     /**
      * Performs test generation for a method when the action is invoked.
      *
      * @param e an action event that contains useful information
      */
     override fun actionPerformed(e: AnActionEvent) {
-//        val project: Project = e.project ?: return
-
         val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
-//        val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-//        val fileName = vFile.presentableUrl
-//        val modificationStamp = vFile.modificationStamp
 
         val psiMethod: PsiMethod = getSurroundingMethod(psiFile, caret) ?: return
-//        val containingClass: PsiClass = psiMethod.containingClass ?: return
-
-//        val classFQN = containingClass.qualifiedName ?: return
         val methodDescriptor = generateMethodDescriptor(psiMethod)
 
-//        val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
-//        val projectClassPath = "$projectPath/target/classes/"
-//
-//        log.info("Generating tests for project $projectPath with classpath $projectClassPath")
-
-        Logger.getInstance("Test Generation").info("Selected method is $methodDescriptor")
+        Logger.getInstance("GenerateTestsUtils").info("Selected method is $methodDescriptor")
 
         evoSuiteRunner.forMethod(methodDescriptor).runEvoSuite()
     }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
@@ -19,7 +19,7 @@ class GenerateTestsActionMethod : AnAction() {
     /**
      * Creates and calls (EvoSuite) Runner to generate tests for a method when the action is invoked.
      *
-     * @param e an action event that contains useful information
+     * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun actionPerformed(e: AnActionEvent) {
         val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
@@ -39,7 +39,7 @@ class GenerateTestsActionMethod : AnAction() {
      * Makes the action visible only if a method has been selected.
      * It also updates the action name depending on which method has been selected.
      *
-     * @param e an action event that contains useful information
+     * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
@@ -16,6 +16,8 @@ import nl.tudelft.ewi.se.ciselab.testgenie.helpers.generateMethodDescriptor
  *   getting the information about the selected method and passing it to (EvoSuite) Runner.
  */
 class GenerateTestsActionMethod : AnAction() {
+    private val logger: Logger = Logger.getInstance(this.javaClass)
+
     /**
      * Creates and calls (EvoSuite) Runner to generate tests for a method when the action is invoked.
      *
@@ -30,7 +32,7 @@ class GenerateTestsActionMethod : AnAction() {
         val psiMethod: PsiMethod = getSurroundingMethod(psiFile, caret) ?: return
         val methodDescriptor = generateMethodDescriptor(psiMethod)
 
-        Logger.getInstance("GenerateTestsUtils").info("Selected method is $methodDescriptor")
+        logger.info("Selected method is $methodDescriptor")
 
         evoSuiteRunner.forMethod(methodDescriptor).runEvoSuite()
     }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
@@ -17,7 +17,7 @@ import nl.tudelft.ewi.se.ciselab.testgenie.helpers.generateMethodDescriptor
  */
 class GenerateTestsActionMethod : AnAction() {
     /**
-     * Performs test generation for a method when the action is invoked.
+     * Creates and calls (EvoSuite) Runner to generate tests for a method when the action is invoked.
      *
      * @param e an action event that contains useful information
      */

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
@@ -67,8 +67,8 @@ fun getSurroundingMethod(psiFile: PsiFile, caret: Caret): PsiMethod? {
 fun getSurroundingLine(doc: Document, caret: Caret): Int? {
     val line = doc.getLineNumber(caret.offset)
 
-    val text = doc.getText(TextRange(doc.getLineStartOffset(line), doc.getLineEndOffset(line)))
-        .replace(Regex("[\n\t{} ]"), "")
+    val text =
+        doc.getText(TextRange(doc.getLineStartOffset(line), doc.getLineEndOffset(line))).replace(Regex("[\n\t{} ]"), "")
     return if (text.isBlank()) null else line
 }
 
@@ -130,6 +130,12 @@ private fun isAbstractClass(psiClass: PsiClass): Boolean {
  */
 private fun validateClass(psiClass: PsiClass): Boolean {
     return !psiClass.isEnum && psiClass !is PsiAnonymousClass
+}
+
+fun validateLine(line: Int, psiMethod: PsiMethod, doc: Document): Boolean {
+    val startDeclaration: Int = doc.getLineNumber(psiMethod.startOffset)
+    val startBody: Int = doc.getLineNumber(psiMethod.body?.startOffset!!)
+    return line >= startBody + 1
 }
 
 /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
@@ -40,7 +40,7 @@ fun createEvoSuiteRunner(e: AnActionEvent): Runner? {
     val projectPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
     val projectClassPath = "$projectPath/target/classes/"
 
-    val log = Logger.getInstance("Test Generation")
+    val log = Logger.getInstance("GenerateTestsUtils")
 
     log.info("Generating tests for project $projectPath with classpath $projectClassPath")
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
@@ -67,6 +67,15 @@ fun getSurroundingMethod(psiFile: PsiFile, caret: Caret): PsiMethod? {
     return surroundingMethod
 }
 
+/**
+ * Gets the selected line if the constraints on the selected line are satisfied,
+ *   so that EvoSuite can generate tests for it.
+ * Namely, the line is within a method, it is not blank and contains (part of) a statement.
+ *
+ * @param psiFile the current PSI file (where the user makes the click)
+ * @param caret the current (primary) caret that did the click
+ * @return line number if the constraints are satisfied else null
+ */
 fun getSurroundingLine(psiFile: PsiFile, caret: Caret): Int? {
     val psiMethod: PsiMethod = getSurroundingMethod(psiFile, caret) ?: return null
 
@@ -140,6 +149,15 @@ private fun validateClass(psiClass: PsiClass): Boolean {
     return !psiClass.isEnum && psiClass !is PsiAnonymousClass
 }
 
+/**
+ * Checks if the selected line contains (part of) a statement and is a valid line to be selected for EvoSuite.
+ * Namely, the line is within a method, it is not blank and contains (part of) a statement.
+ *
+ * @param selectedLine selected line number
+ * @param psiMethod surrounding PSI method
+ * @param psiFile containing PSI file
+ * @return true if the line is valid, false otherwise
+ */
 private fun validateLine(selectedLine: Int, psiMethod: PsiMethod, psiFile: PsiFile): Boolean {
     val doc: Document = PsiDocumentManager.getInstance(psiFile.project).getDocument(psiFile) ?: return false
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
@@ -132,10 +132,48 @@ private fun validateClass(psiClass: PsiClass): Boolean {
     return !psiClass.isEnum && psiClass !is PsiAnonymousClass
 }
 
-fun validateLine(line: Int, psiMethod: PsiMethod, doc: Document): Boolean {
-    val startDeclaration: Int = doc.getLineNumber(psiMethod.startOffset)
-    val startBody: Int = doc.getLineNumber(psiMethod.body?.startOffset!!)
-    return line >= startBody + 1
+fun validateLine(offset: Int, psiMethod: PsiMethod, doc: Document): Boolean {
+    val line: Int = doc.getLineNumber(offset)
+
+    val openingBraceOffset: Int = psiMethod.body?.lBrace?.startOffset!!
+    val closingBraceOffset: Int = psiMethod.body?.rBrace?.startOffset!!
+
+    val openingBraceLine: Int = doc.getLineNumber(openingBraceOffset)
+    val closingBraceLine: Int = doc.getLineNumber(closingBraceOffset)
+
+    println("Opening brace offset: $openingBraceOffset")
+    println("Closing brace offset: $closingBraceOffset")
+
+    println("Opening brace line: ${openingBraceLine + 1}")
+    println("Closing brace line: ${closingBraceLine + 1}")
+
+    println(
+        "Opening brace line offsets: (${doc.getLineStartOffset(openingBraceLine)},${
+        doc.getLineEndOffset(
+            openingBraceLine
+        )
+        }"
+    )
+    println(
+        "Closing brace line offsets: (${doc.getLineStartOffset(closingBraceLine)},${
+        doc.getLineEndOffset(
+            closingBraceLine
+        )
+        }"
+    )
+
+    if (openingBraceLine == closingBraceLine) return line == openingBraceLine
+
+    // Figure out case 3.1, 3.1.1 and 3.2
+    if (openingBraceLine + 1 == closingBraceLine) {
+        // do something
+    }
+    // ...
+
+    if (line <= openingBraceLine) return false
+    val text =
+        doc.getText(TextRange(doc.getLineStartOffset(line), doc.getLineEndOffset(line))).replace(Regex("[\n\t{} ]"), "")
+    return !text.isBlank()
 }
 
 /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
@@ -1,6 +1,8 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.actions
 
 import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiAnonymousClass
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
@@ -60,6 +62,14 @@ fun getSurroundingMethod(psiFile: PsiFile, caret: Caret): PsiMethod? {
         }
     }
     return surroundingMethod
+}
+
+fun getSurroundingLine(doc: Document, caret: Caret): Int? {
+    val line = doc.getLineNumber(caret.offset)
+
+    val text = doc.getText(TextRange(doc.getLineStartOffset(line), doc.getLineEndOffset(line)))
+        .replace(Regex("[\n\t{} ]"), "")
+    return if (text.isBlank()) null else line
 }
 
 /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
@@ -25,6 +25,12 @@ import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
  * This file contains some useful methods related to GenerateTests actions.
  */
 
+/**
+ * Extracts the required information from an action event and creates an (EvoSuite) runner.
+ *
+ * @param e an action event that contains useful information and corresponds to the action invoked by the user
+ * @return the created (EvoSuite) Runner, null if some information is missing or if there is no surrounding class
+ */
 fun createEvoSuiteRunner(e: AnActionEvent): Runner? {
     val project: Project = e.project ?: return null
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsUtils.kt
@@ -86,7 +86,9 @@ fun getSurroundingLine(psiFile: PsiFile, caret: Caret): Int? {
         doc.getText(TextRange(doc.getLineStartOffset(selectedLine), doc.getLineEndOffset(selectedLine)))
 
     if (selectedLineText.isBlank()) return null
-    return if (!validateLine(selectedLine, psiMethod, psiFile)) null else selectedLine
+
+    if (!validateLine(selectedLine, psiMethod, psiFile)) return null
+    return selectedLine
 }
 
 /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
@@ -87,6 +87,17 @@ class Runner(
     }
 
     /**
+     * Sets up evosuite to run for a target line of the target class. This attaches the selected line argument
+     * to the evosuite process.
+     */
+    fun forLine(selectedLine: Int): Runner {
+        command = SettingsArguments(projectClassPath, projectPath, serializeResultPath, classFQN).forLine(selectedLine)
+            .build()
+
+        return this
+    }
+
+    /**
      * Performs final argument preparation and launches the evosuite process on a separate thread.
      *
      * @return the path to which results will be (eventually) saved

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/SettingsArguments.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/SettingsArguments.kt
@@ -33,17 +33,33 @@ class SettingsArguments(
 
     /**
      * Appends a method parameter to the command.
-     * This makes EvoSuite create goals only for a certain method
-     * of the CUT.
+     * This makes EvoSuite create goals only for a certain method of the CUT.
      *
      * See https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.3
      *
      * @param method The descriptor of the method we're generating tests for
+     * @return the instance object
      */
     fun forMethod(method: String): SettingsArguments {
         command.addAll(
             listOf(
                 "-Dtarget_method=$method"
+            )
+        )
+        return this
+    }
+
+    /**
+     * Appends a line parameter to the command.
+     * This makes EvoSuite create goals only for a certain line of the CUT.
+     *
+     * @param line the selected line
+     * @return the instance object
+     */
+    fun forLine(line: Int): SettingsArguments {
+        command.addAll(
+            listOf(
+                "-Dtarget_line=$line"
             )
         )
         return this

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,6 +62,13 @@
                     description="Generate tests for the selected method using TestGenie">
                 <keyboard-shortcut first-keystroke="control alt shift G" second-keystroke="M" keymap="$default"/>
             </action>
+            <!-- Generate tests for lines -->
+            <action class="nl.tudelft.ewi.se.ciselab.testgenie.actions.GenerateTestsActionLine"
+                    id="TestGenie.TestGenieActions.GenerateTestsForLine"
+                    text="Generate Tests For Line"
+                    description="Generate tests for the selected line using TestGenie">
+                <keyboard-shortcut first-keystroke="control alt shift G" second-keystroke="L" keymap="$default"/>
+            </action>
         </group>
     </actions>
 </idea-plugin>

--- a/src/test/resources/pizzeria/src/PizzaClasse.java
+++ b/src/test/resources/pizzeria/src/PizzaClasse.java
@@ -1,0 +1,54 @@
+import java.util.ArrayList;
+import java.util.List;
+
+public class PizzaClasse {
+    private static final int prezzoBase = 42;
+
+    public static void main(String[] args) {
+        pizzaMetodo();
+        pizzaMetodo(256);
+
+        PizzaServizio pizzaServizio = new PizzaServizio() {
+            @Override
+            public PizzaAstratta fareLaPizza() {
+                return new BuonaPizza();
+            }
+        };
+
+        pizzaServizio.saluto();
+        PizzaAstratta pizza = pizzaServizio.fareLaPizza();
+
+    }
+
+    public static void pizzaMetodo() {
+        System.out.println("Io sono una buona pizza! Mi costa " + prezzoBase + " euro.");
+    }
+
+    public static void pizzaMetodo(int prezzo) {
+        System.out.println("Io sono una buona pizza! Mi costa " + prezzo + " euro.");
+    }
+}
+
+interface PizzaServizio {
+    default void saluto() {
+        System.out.println("Viva la pizza Italiana");
+    }
+
+    PizzaAstratta fareLaPizza();
+}
+
+abstract class PizzaAstratta {
+    public void saluto() {
+        System.out.println("Io sono una pizza astratta. Non posso essere istanziato");
+    }
+
+    public abstract List<String> selencaGliIngredienti();
+}
+
+class BuonaPizza extends PizzaAstratta {
+
+    @Override
+    public List<String> selencaGliIngredienti() {
+        return List.of("Salame", "Mozzarella", "Salsa di pomodoro");
+    }
+}


### PR DESCRIPTION
# Description of changes made
Line selection for test generation is now supported. Invalid lines are not allowed to be selected.

# Why is merge request needed
This merge request is important since it adds the ability to select the lines for test generation which is part of an issue requested by the client.

# Other notes
Closes #12 


# What is missing?
- Dealing with the output tests generated by EvoSuite

- [x] I have checked that I am merging into correct branch
