### PR TITLE
Dynamic highlight visualisation

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -1,6 +1,5 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.services
 
-import com.google.gson.Gson
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.ide.util.TreeClassChooserFactory
 import com.intellij.openapi.command.WriteCommandAction
@@ -16,7 +15,6 @@ import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentFactory
 import nl.tudelft.ewi.se.ciselab.testgenie.editor.Workspace
 import org.evosuite.utils.CompactReport
-import org.evosuite.utils.CompactTestCase
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
@@ -38,6 +36,8 @@ class TestCaseDisplayService(private val project: Project) {
     private var testCheckboxes: MutableList<Pair<JCheckBox, String>> = mutableListOf()
     private var unhighlightList: MutableList<String> = mutableListOf()
     private val originalCompactReports: HashMap<String, CompactReport> = HashMap()
+    private val coveredLinesSet: MutableSet<Int> = mutableSetOf()
+    private val allCoveredLines: MutableSet<Int> = mutableSetOf()
 
     // Variable to keep reference to the coverage visualisation content
     private var content: Content? = null
@@ -138,62 +138,31 @@ class TestCaseDisplayService(private val project: Project) {
      * Works by replicating the original file within the Workspace, then changing its values and placing the new version in Workspace
      * @param checkbox the checkbox to add listener to
      * @param testName the name of the test to add/remove from unhighlightList
-     * @param reportFetched the compactReport with the tests
+     * @param report the compactReport with the tests
      */
-    private fun addCheckboxListener(checkbox: JCheckBox, testName: String, reportFetched: CompactReport): (ActionEvent) -> Unit = {
+    private fun addCheckboxListener(checkbox: JCheckBox, testName: String, report: CompactReport): (ActionEvent) -> Unit = {
         if (checkbox.isSelected) {
             unhighlightList.remove(testName)
         } else {
             unhighlightList.add(testName)
         }
 
-        val originalResult = project.service<Workspace>().getTestGenerationResult(reportFetched)
+        // fetch the report
+        val originalResult = project.service<Workspace>().getTestGenerationResult(report)
 
-        var report = reportFetched
-
-        // Always use the root report. That's the report with all the tests still in it
-        // Otherwise, we will lose information if we deselect multiple tests
-        if (originalCompactReports.containsKey(originalResult.first)) {
-            // Deep copy required
-            report = deepCopy(originalCompactReports.get(originalResult.first) ?: reportFetched)
-        } else {
-            originalCompactReports.put(originalResult.first, deepCopy(reportFetched))
-        }
-
-        // copy report
-        val reportNew: CompactReport = report
-
-        val removedNames = mutableListOf<Pair<String, CompactTestCase?>>()
-
-        // remove tests which are not selected
-        unhighlightList.forEach {
-            val test = reportNew.testCaseList.remove(it)
-            removedNames.add(Pair(it, test))
-        }
-        val coveredLinesNew: MutableSet<Int> = mutableSetOf()
-
-        // only count the covered lines of selected tests
+        // add only the lines of the tests which have been selected
+        coveredLinesSet.clear()
         report.testCaseList.forEach {
-            coveredLinesNew.addAll(it.value.coveredLines)
+            if (!unhighlightList.contains(it.key)) {
+                coveredLinesSet.addAll(it.value.coveredLines)
+            }
         }
-
-        reportNew.allCoveredLines = coveredLinesNew
+        // make the report use only associated lines
+        report.allCoveredLines = coveredLinesSet
 
         // replace original file in workplace
         project.service<Workspace>().addPendingResult(originalResult.first, originalResult.second)
-        project.service<Workspace>().receiveGenerationResult(originalResult.first, reportNew)
-    }
-
-    /**
-     * Makes a deep copy of the compact report
-     * Credits to https://medium.com/@gugabernardo/here-is-the-easiest-way-to-deep-copy-an-object-in-kotlin-cf200c2130b
-     * @param report the compactReport to make the copy of
-     * @return copy of compactReport
-     */
-    private fun deepCopy(report: CompactReport): CompactReport {
-        val gson = Gson()
-        val json = gson.toJson(report)
-        return gson.fromJson(json, CompactReport::class.java)
+        project.service<Workspace>().receiveGenerationResult(originalResult.first, report)
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -148,7 +148,7 @@ class TestCaseDisplayService(private val project: Project) {
         }
 
         // fetch the report
-        val originalResult = project.service<Workspace>().getTestGenerationResult(report)
+        val originalResult = project.service<Workspace>().getTestGenerationResult(report)!!
 
         // add only the lines of the tests which have been selected
         coveredLinesSet.clear()
@@ -161,7 +161,7 @@ class TestCaseDisplayService(private val project: Project) {
         report.allCoveredLines = coveredLinesSet
 
         // replace original file in workplace
-        project.service<Workspace>().addPendingResult(originalResult.first, originalResult.second)
+        project.service<Workspace>().addPendingResult(originalResult!!.first, originalResult.second)
         project.service<Workspace>().receiveGenerationResult(originalResult.first, report)
     }
 


### PR DESCRIPTION
# Description of changes made
Coverage visualisation can now be adjusted on the fly. Deselected tests (in mini-editors) will not be counted for in highlighting. Re-selecting test restores their highlight. So, the user can now see the highlights for only those tests they selected.

# Why is merge request needed
This increases usability a lot. The program adjusts to the user's wishes, they can experiment with what tests they want to choose.

# Other notes
Closes # (tbd)

*Please write if you have anything to add*

# What is missing?
-

- [x] I have checked that I am merging into correct branch
