### PR TITLE
Fix broken coverage visualization

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
@@ -30,7 +30,7 @@ class GenerateTestsActionClass : AnAction() {
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val caret: Caret = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return
         val vFile = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-        val fileName = vFile.presentableUrl
+        val fileUrl = vFile.presentableUrl
         val modificationStamp = vFile.modificationStamp
 
         val psiClass: PsiClass = getSurroundingClass(psiFile, caret) ?: return
@@ -43,7 +43,7 @@ class GenerateTestsActionClass : AnAction() {
 
         log.info("Selected class is $classFQN")
 
-        Runner(project, projectPath, projectClassPath, classFQN, fileName, modificationStamp).forClass().runEvoSuite()
+        Runner(project, projectPath, projectClassPath, classFQN, fileUrl, modificationStamp).forClass().runEvoSuite()
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
@@ -38,7 +38,7 @@ class Runner(
     private val projectPath: String,
     private val projectClassPath: String,
     private val classFQN: String,
-    private val fileName: String,
+    private val fileUrl: String,
     private val modTs: Long
 ) {
     private val log = Logger.getInstance(this::class.java)
@@ -54,7 +54,7 @@ class Runner(
     private val testResultDirectory = "${FileUtilRt.getTempDirectory()}${sep}testGenieResults$sep"
     private val testResultName = "test_gen_result_$id"
 
-    private var key = Workspace.TestJobInfo(fileName, classFQN, modTs, testResultName)
+    private var key = Workspace.TestJobInfo(fileUrl, classFQN, modTs, testResultName)
 
     private val serializeResultPath = "\"$testResultDirectory$testResultName\""
 
@@ -86,7 +86,7 @@ class Runner(
                 .build()
 
         // attach method desc. to target unit key
-        key = Workspace.TestJobInfo(fileName, "$classFQN#$methodDescriptor", modTs, testResultName)
+        key = Workspace.TestJobInfo(fileUrl, "$classFQN#$methodDescriptor", modTs, testResultName)
 
         return this
     }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -40,7 +40,7 @@ class CoverageVisualisationService(private val project: Project) {
 
             val service = TestGenieSettingsService.getInstance().state
             val color = Color(service!!.colorRed, service.colorGreen, service.colorBlue)
-            val colorForLines = Color(service!!.colorRed, service.colorGreen, service.colorBlue, 30)
+            val colorForLines = Color(service.colorRed, service.colorGreen, service.colorBlue, 30)
 
             editor.markupModel.removeAllHighlighters()
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/toolwindow/QuickAccessParameters.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/toolwindow/QuickAccessParameters.kt
@@ -28,11 +28,7 @@ import javax.swing.SpinnerNumberModel
 /**
  * This class stores the main panel and the UI of the "Parameters" tool window tab.
  */
-class QuickAccessParameters(_project: Project) {
-
-    // Current Project
-    private var project: Project = _project
-
+class QuickAccessParameters(private val project: Project) {
     // UI elements for EvoSuite parameters
     private val stoppingCondition: ComboBox<StoppingCondition> = ComboBox<StoppingCondition>(StoppingCondition.values())
     private val searchBudget: JSpinner = JSpinner(SpinnerNumberModel(0, 0, 10000, 1))


### PR DESCRIPTION
# Description of changes made
Intellij has a weird perception of what a file's modification timestamp is. There are some odd cases where we cannot entirely depend on a file's mod ts for its state. As such, we won't retrigger coverage visualization whenever we detect file timestamp changes.