### PR TITLE
Fix UI tests for macOS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -146,6 +146,7 @@ tasks {
         systemProperty("ide.show.tips.on.startup.default.value", "false")
         systemProperty("jb.consents.confirmation.enabled", "false")
         systemProperty("ide.mac.file.chooser.native", "false")
+        systemProperty("apple.laf.useScreenMenuBar", "false")
     }
 
     signPlugin {

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/QuickAccessParametersTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/QuickAccessParametersTest.kt
@@ -389,14 +389,15 @@ class QuickAccessParametersTest {
         find<JButtonFixture>(byXpath("//div[@text='No']")).click()
 
         // Assert that nothing has been modified
+        val separator: String = if (remoteRobot.isMac()) "." else "," // The separator of coma and fullstops is different on macOS
         assertThat(quickAccessParameters.searchBudgetTypeComboBox.hasText(searchBudgetTypeNew))
-        assertThat(quickAccessParameters.searchBudgetValueSpinnerTextField.text.replace(",", "")).isEqualTo(searchBudgetValueNew)
-        assertThat(quickAccessParameters.initializationTimeoutSpinnerTextField.text.replace(",", "")).isEqualTo(initializationTimeoutNew)
-        assertThat(quickAccessParameters.minimizationTimeoutSpinnerTextField.text.replace(",", "")).isEqualTo(minimizationTimeoutNew)
-        assertThat(quickAccessParameters.assertionTimeoutSpinnerTextField.text.replace(",", "")).isEqualTo(assertionTimeoutNew)
-        assertThat(quickAccessParameters.jUnitCheckTimeoutSpinnerTextField.text.replace(",", "")).isEqualTo(junitCheckTimeoutNew)
+        assertThat(quickAccessParameters.searchBudgetValueSpinnerTextField.text.replace(separator, "")).isEqualTo(searchBudgetValueNew)
+        assertThat(quickAccessParameters.initializationTimeoutSpinnerTextField.text.replace(separator, "")).isEqualTo(initializationTimeoutNew)
+        assertThat(quickAccessParameters.minimizationTimeoutSpinnerTextField.text.replace(separator, "")).isEqualTo(minimizationTimeoutNew)
+        assertThat(quickAccessParameters.assertionTimeoutSpinnerTextField.text.replace(separator, "")).isEqualTo(assertionTimeoutNew)
+        assertThat(quickAccessParameters.jUnitCheckTimeoutSpinnerTextField.text.replace(separator, "")).isEqualTo(junitCheckTimeoutNew)
         assertThat(quickAccessParameters.populationLimitComboBox.hasText(populationLimitNew))
-        assertThat(quickAccessParameters.populationValueSpinnerTextField.text.replace(",", "")).isEqualTo(populationValueNew)
+        assertThat(quickAccessParameters.populationValueSpinnerTextField.text.replace(separator, "")).isEqualTo(populationValueNew)
 
         // Now actually reset the values to defaults and assert that it has been successful
         reset()

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/QuickAccessParametersTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/QuickAccessParametersTest.kt
@@ -461,9 +461,6 @@ class QuickAccessParametersTest {
      */
     @AfterAll
     fun closeAll(remoteRobot: RemoteRobot): Unit = with(remoteRobot) {
-        // Reset all the parameters to defaults to prevent flakiness
-        reset()
-
         // Close the tool window tab
         find(IdeaFrame::class.java, timeout = Duration.ofSeconds(15)).apply {
             clickOnToolWindow()

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
@@ -286,7 +286,7 @@ class SettingsComponentTest {
         // This assertion on macOS is different. Reason is unclear.
         if (remoteRobot.isMac()) {
             assertThat(errorDialog.hasText("Seed parameter is not of numeric type. Therefore, it will not be saved." +
-                    " However, the rest of the parameters have been successfully saved."))
+                    " However, the rest of the parameters have been successfully saved.")).isTrue
         } else {
             assertThat(errorDialog.hasText("'Incorrect Numeric Type For Seed'")).isTrue
         }

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
@@ -37,13 +37,7 @@ class SettingsComponentTest {
 
         find(IdeaFrame::class.java, timeout = Duration.ofSeconds(60)).apply {
             waitForBackgroundTasks()
-            // Check if operating system is Mac
-            if (remoteRobot.isMac()) { // If so then we need another way to open settings
-                clickOnToolWindow() // Open sidebar tool window
-                advancedSettingsButton() // Use action link in quick access parameters to open settings
-            } else {
-                openSettings()
-            }
+            openSettings(false)
         }
     }
 
@@ -84,12 +78,7 @@ class SettingsComponentTest {
 
         // Open settings again
         val ideaFrame = find(IdeaFrame::class.java, timeout = Duration.ofSeconds(15))
-        // Check if operating system is Mac
-        if (remoteRobot.isMac()) { // If so then we need another way to open settings
-            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
-        } else {
-            ideaFrame.openSettings()
-        }
+        ideaFrame.openSettings(true)
 
         // Find again TestGenie
         settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(15))
@@ -101,12 +90,7 @@ class SettingsComponentTest {
         settingsFrame.okSettings()
 
         // Open settings again
-        // Check if operating system is Mac
-        if (remoteRobot.isMac()) { // If so then we need another way to open settings
-            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
-        } else {
-            ideaFrame.openSettings()
-        }
+        ideaFrame.openSettings(true)
     }
 
     @Order(4)
@@ -174,12 +158,7 @@ class SettingsComponentTest {
 
         // Open settings again
         val ideaFrame = find(IdeaFrame::class.java, timeout = Duration.ofSeconds(15))
-        // Check if operating system is Mac
-        if (remoteRobot.isMac()) { // If so then we need another way to open settings
-            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
-        } else {
-            ideaFrame.openSettings()
-        }
+        ideaFrame.openSettings(true)
 
         // Find again EvoSuite
         settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(15))
@@ -195,12 +174,7 @@ class SettingsComponentTest {
         settingsFrame.okSettings()
 
         // Open settings again
-        // Check if operating system is Mac
-        if (remoteRobot.isMac()) { // If so then we need another way to open settings
-            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
-        } else {
-            ideaFrame.openSettings()
-        }
+        ideaFrame.openSettings(true)
     }
 
     private fun helperGeneralCheckBoxes(settingsFrame: SettingsFrame): List<JCheckboxFixture> {
@@ -235,12 +209,7 @@ class SettingsComponentTest {
 
         // Open settings again
         val ideaFrame = find(IdeaFrame::class.java, timeout = Duration.ofSeconds(15))
-        // Check if operating system is Mac
-        if (remoteRobot.isMac()) { // If so then we need another way to open settings
-            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
-        } else {
-            ideaFrame.openSettings()
-        }
+        ideaFrame.openSettings(true)
 
         // Find again EvoSuite
         settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(15))
@@ -264,12 +233,7 @@ class SettingsComponentTest {
         settingsFrame.okSettings()
 
         // Open settings again
-        // Check if operating system is Mac
-        if (remoteRobot.isMac()) { // If so then we need another way to open settings
-            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
-        } else {
-            ideaFrame.openSettings()
-        }
+        ideaFrame.openSettings(true)
     }
 
     @Order(8)

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
@@ -310,7 +310,7 @@ class SettingsComponentTest {
         }
 
         find(IdeaFrame::class.java, timeout = Duration.ofSeconds(60)).apply {
-            clickOnToolWindow() // Close the tool window to preserve correct IdeaFrame state
+            if (remoteRobot.isMac()) clickOnToolWindow() // Close the tool window to preserve correct IdeaFrame state
             closeProject()
         }
     }

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
@@ -38,13 +38,19 @@ class SettingsComponentTest {
 
         find(IdeaFrame::class.java, timeout = Duration.ofSeconds(60)).apply {
             waitForBackgroundTasks()
-            openSettings()
+            // Check if operating system is Mac
+            if (remoteRobot.isMac()) { // If so then we need another way to open settings
+                clickOnToolWindow() // Open sidebar tool window
+                advancedSettingsButton() // Use action link in quick access parameters to open settings
+            } else {
+                openSettings()
+            }
         }
     }
 
     @Order(1)
     @Test
-    @Video
+    // @Video
     fun checkTestGenieTabExists(remoteRobot: RemoteRobot) = with(remoteRobot) {
         val settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(60))
         settingsFrame.searchTextBox.text = "TestGenie"
@@ -59,7 +65,7 @@ class SettingsComponentTest {
 
     @Order(2)
     @Test
-    @Video
+    // @Video
     fun checkTestGenieInSettings(remoteRobot: RemoteRobot): Unit = with(remoteRobot) {
         val settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(60))
         settingsFrame.findTestGenie()
@@ -79,7 +85,12 @@ class SettingsComponentTest {
 
         // Open settings again
         val ideaFrame = find(IdeaFrame::class.java, timeout = Duration.ofSeconds(15))
-        ideaFrame.openSettings()
+        // Check if operating system is Mac
+        if (remoteRobot.isMac()) { // If so then we need another way to open settings
+            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
+        } else {
+            ideaFrame.openSettings()
+        }
 
         // Find again TestGenie
         settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(15))
@@ -91,12 +102,17 @@ class SettingsComponentTest {
         settingsFrame.okSettings()
 
         // Open settings again
-        ideaFrame.openSettings()
+        // Check if operating system is Mac
+        if (remoteRobot.isMac()) { // If so then we need another way to open settings
+            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
+        } else {
+            ideaFrame.openSettings()
+        }
     }
 
     @Order(4)
     @Test
-    @Video
+    // @Video
     fun checkEvoSuiteTabExists(remoteRobot: RemoteRobot) = with(remoteRobot) {
         val settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(60))
         settingsFrame.searchTextBox.text = "EvoSuite"
@@ -111,7 +127,7 @@ class SettingsComponentTest {
 
     @Order(5)
     @Test
-    @Video
+    // @Video
     fun checkEvoSuiteInSettings(remoteRobot: RemoteRobot): Unit = with(remoteRobot) {
         val settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(60))
         settingsFrame.findEvoSuite()
@@ -159,7 +175,12 @@ class SettingsComponentTest {
 
         // Open settings again
         val ideaFrame = find(IdeaFrame::class.java, timeout = Duration.ofSeconds(15))
-        ideaFrame.openSettings()
+        // Check if operating system is Mac
+        if (remoteRobot.isMac()) { // If so then we need another way to open settings
+            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
+        } else {
+            ideaFrame.openSettings()
+        }
 
         // Find again EvoSuite
         settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(15))
@@ -175,7 +196,12 @@ class SettingsComponentTest {
         settingsFrame.okSettings()
 
         // Open settings again
-        ideaFrame.openSettings()
+        // Check if operating system is Mac
+        if (remoteRobot.isMac()) { // If so then we need another way to open settings
+            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
+        } else {
+            ideaFrame.openSettings()
+        }
     }
 
     private fun helperGeneralCheckBoxes(settingsFrame: SettingsFrame): List<JCheckboxFixture> {
@@ -210,7 +236,12 @@ class SettingsComponentTest {
 
         // Open settings again
         val ideaFrame = find(IdeaFrame::class.java, timeout = Duration.ofSeconds(15))
-        ideaFrame.openSettings()
+        // Check if operating system is Mac
+        if (remoteRobot.isMac()) { // If so then we need another way to open settings
+            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
+        } else {
+            ideaFrame.openSettings()
+        }
 
         // Find again EvoSuite
         settingsFrame = find(SettingsFrame::class.java, timeout = Duration.ofSeconds(15))
@@ -234,7 +265,12 @@ class SettingsComponentTest {
         settingsFrame.okSettings()
 
         // Open settings again
-        ideaFrame.openSettings()
+        // Check if operating system is Mac
+        if (remoteRobot.isMac()) { // If so then we need another way to open settings
+            ideaFrame.advancedSettingsButton() // Use action link in quick access parameters to open settings
+        } else {
+            ideaFrame.openSettings()
+        }
     }
 
     @Order(8)
@@ -247,7 +283,13 @@ class SettingsComponentTest {
         val errorDialog: CommonContainerFixture =
             find(settingsFrame.seedDialogLocator, timeout = Duration.ofSeconds(15))
 
-        assertThat(errorDialog.hasText("Incorrect Numeric Type For Seed")).isTrue
+        // This assertion on macOS is different. Reason is unclear.
+        if (remoteRobot.isMac()) {
+            assertThat(errorDialog.hasText("Seed parameter is not of numeric type. Therefore, it will not be saved." +
+                    " However, the rest of the parameters have been successfully saved."))
+        } else {
+            assertThat(errorDialog.hasText("'Incorrect Numeric Type For Seed'")).isTrue
+        }
 
         val okDialog: JButtonFixture?
 
@@ -268,6 +310,7 @@ class SettingsComponentTest {
         }
 
         find(IdeaFrame::class.java, timeout = Duration.ofSeconds(60)).apply {
+            clickOnToolWindow() // Close the tool window to preserve correct IdeaFrame state
             closeProject()
         }
     }

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/SettingsComponentTest.kt
@@ -1,6 +1,5 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.uiTest
 
-import com.automation.remarks.junit5.Video
 import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.fixtures.CommonContainerFixture
 import com.intellij.remoterobot.fixtures.JButtonFixture
@@ -283,13 +282,13 @@ class SettingsComponentTest {
         val errorDialog: CommonContainerFixture =
             find(settingsFrame.seedDialogLocator, timeout = Duration.ofSeconds(15))
 
-        // This assertion on macOS is different. Reason is unclear.
-        if (remoteRobot.isMac()) {
-            assertThat(errorDialog.hasText("Seed parameter is not of numeric type. Therefore, it will not be saved." +
-                    " However, the rest of the parameters have been successfully saved.")).isTrue
-        } else {
-            assertThat(errorDialog.hasText("'Incorrect Numeric Type For Seed'")).isTrue
-        }
+        // Assertion to check if the error message is correct.
+        assertThat(
+            errorDialog.hasText(
+                "Seed parameter is not of numeric type. Therefore, it will not be saved." +
+                    " However, the rest of the parameters have been successfully saved."
+            )
+        ).isTrue
 
         val okDialog: JButtonFixture?
 

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/IdeaFrame.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/IdeaFrame.kt
@@ -58,7 +58,11 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
     fun openSettings(toolWindowOpen: Boolean) {
         // Check if operating system is Mac
         if (remoteRobot.isMac()) { // If so then we need another way to open settings
-            if (!toolWindowOpen) openToolWindow.click() // Open sidebar tool window if it is not already open
+            if (!toolWindowOpen) {
+                openToolWindow.click() // Open sidebar tool window if it is not already open
+                openToolWindow.click() // Open and close the tool window to get rid of...
+                openToolWindow.click() // ... horizontal scroll bar that right on top of advanceSettingsButton
+            }
             advancedSettingsButton.click() // Use action link in quick access parameters to open settings
         } else {
             openFileMenu.click()

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/IdeaFrame.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/IdeaFrame.kt
@@ -55,9 +55,15 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
     /**
      * Method to open the settings of IntelliJ.
      */
-    fun openSettings() {
-        openFileMenu.click()
-        openSettingsAction.click()
+    fun openSettings(toolWindowOpen: Boolean) {
+        // Check if operating system is Mac
+        if (remoteRobot.isMac()) { // If so then we need another way to open settings
+            if (!toolWindowOpen) openToolWindow.click() // Open sidebar tool window if it is not already open
+            advancedSettingsButton.click() // Use action link in quick access parameters to open settings
+        } else {
+            openFileMenu.click()
+            openSettingsAction.click()
+        }
     }
 
     /**

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/IdeaFrame.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/IdeaFrame.kt
@@ -40,6 +40,10 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
     private val openToolWindow
         get() = actionLink(byXpath("//div[@tooltiptext='TestGenie']"))
 
+    // The action link text in the quick access parameters of sidebar tool window
+    private val advancedSettingsButton
+        get() = actionLink(byXpath("//div[@class='ActionLink']"))
+
     /**
      * Method to close the current project.
      */
@@ -54,6 +58,14 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
     fun openSettings() {
         openFileMenu.click()
         openSettingsAction.click()
+    }
+
+    /**
+     * Method to open the settings on IntelliJ
+     *  through the action link in the quick access parameters in the sidebar tool window.
+     */
+    fun advancedSettingsButton() {
+        advancedSettingsButton.click()
     }
 
     /**

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/SettingsFrame.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/uiTest/pages/SettingsFrame.kt
@@ -18,7 +18,7 @@ import java.time.Duration
  */
 
 @FixtureName("Settings Frame")
-@DefaultXpath("type", "//div[@class='MyDialog' and @title='Settings']")
+@DefaultXpath("type", "//div[@class='MyDialog']")
 class SettingsFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
     CommonContainerFixture(remoteRobot, remoteComponent) {
 


### PR DESCRIPTION
# Description of changes made
In this pull request most changes happened in the UI testing classes. Specifically, SettingsComponentTest and QuickAcessParametersTest. Nothing major was changed in terms of logic, there were only changes that made the tests more compatible with the macOS. 
Each change, along with reasoning is documented in the commits, feel free to check those when reviewing. 

# Why is merge request needed
This merge request is needed to adopt the current UI tests to macOS platform. 

# Other notes
Closes #109 

*Please write if you have anything to add*
A few lines were edited that belong to other users. Mainly @kirilvasilev16 and @jzelenjak, I hope that they do not mind that. 

# What is missing?
In order to get the tests to work I had to comment out the @Video annotation in the SettingsComponentTest. I am confused if it is necessary to have that annotation for the GitHub actions or not, because it is used inconsistently throughout the project ( SettingsComponentTest and QuickAcessParametersTest classes)

I didn't run the branch on the GitHub actions and the UI tests on dispatch yet, hence I do not know if the changes actually solve the macOS issue on GitHub actions. I do not know what macOS the GitHub actions are using and therefore it is likely that there could be problems. 

- [x] I have checked that I am merging into correct branch
