### PR TITLE
Weaken highlighter priority

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -39,22 +39,7 @@ class CoverageVisualisationService(private val project: Project) {
         val state = ApplicationManager.getApplication().getService(QuickAccessParametersService::class.java).state
         if (state.showCoverage) {
 
-            val service = TestGenieSettingsService.getInstance().state
-            val color = Color(service!!.colorRed, service.colorGreen, service.colorBlue)
-            val colorForLines = Color(service.colorRed, service.colorGreen, service.colorBlue, 30)
-
-            editor.markupModel.removeAllHighlighters()
-            for (i in testReport.allCoveredLines) {
-                val line = i - 1
-                val textAttributesKey = TextAttributesKey.createTextAttributesKey("custom")
-                textAttributesKey.defaultAttributes.backgroundColor = colorForLines
-                val hl = editor.markupModel.addLineHighlighter(textAttributesKey, line, HighlighterLayer.ADDITIONAL_SYNTAX)
-                hl.lineMarkerRenderer = CoverageRenderer(
-                    color,
-                    line,
-                    testReport.testCaseList.filter { x -> i in x.value.coveredLines }.map { x -> x.key }, project
-                )
-            }
+            updateCoverage(testReport.allCoveredLines, testReport.testCaseList.values.toList(), editor)
         }
     }
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -80,7 +80,7 @@ class CoverageVisualisationService(private val project: Project) {
                 val line = i - 1
                 val textAttributesKey = TextAttributesKey.createTextAttributesKey("custom")
                 textAttributesKey.defaultAttributes.backgroundColor = colorForLines
-                val hl = editor.markupModel.addLineHighlighter(textAttributesKey, line, HighlighterLayer.LAST)
+                val hl = editor.markupModel.addLineHighlighter(textAttributesKey, line, HighlighterLayer.ADDITIONAL_SYNTAX)
 
                 hl.lineMarkerRenderer = CoverageRenderer(
                     color,

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -48,7 +48,7 @@ class CoverageVisualisationService(private val project: Project) {
                 val line = i - 1
                 val textAttributesKey = TextAttributesKey.createTextAttributesKey("custom")
                 textAttributesKey.defaultAttributes.backgroundColor = colorForLines
-                val hl = editor.markupModel.addLineHighlighter(textAttributesKey, line, HighlighterLayer.LAST)
+                val hl = editor.markupModel.addLineHighlighter(textAttributesKey, line, HighlighterLayer.ADDITIONAL_SYNTAX)
                 hl.lineMarkerRenderer = CoverageRenderer(
                     color,
                     line,

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -35,12 +35,7 @@ class CoverageVisualisationService(private val project: Project) {
         fillToolWindowContents(testReport)
         createToolWindowTab()
 
-        // Show in-line coverage only if enabled in settings
-        val state = ApplicationManager.getApplication().getService(QuickAccessParametersService::class.java).state
-        if (state.showCoverage) {
-
-            updateCoverage(testReport.allCoveredLines, testReport.testCaseList.values.toList(), editor)
-        }
+        updateCoverage(testReport.allCoveredLines, testReport.testCaseList.values.toList(), editor)
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/CoverageVisualisationService.kt
@@ -26,9 +26,10 @@ class CoverageVisualisationService(private val project: Project) {
     private var content: Content? = null
 
     /**
-     * Shows coverage on the gutter next to the covered lines.
+     * Instantiates tab for coverage table and calls function to update coverage.
      *
      * @param testReport the generated tests summary
+     * @param editor editor whose contents tests were generated for
      */
     fun showCoverage(testReport: CompactReport, editor: Editor) {
         // Show toolWindow statistics
@@ -39,6 +40,7 @@ class CoverageVisualisationService(private val project: Project) {
     }
 
     /**
+     * Highlights lines covered by selected tests.
      * Shows coverage on the gutter next to the covered lines.
      *
      * @param linesToCover total set of lines  to cover


### PR DESCRIPTION
# Description of changes made
Highlighter is now of "Additional Syntax" priority. This means that things like selecting code (with mouse), will be visible above the highlighter.

# Why is merge request needed
Selecting code with your mouse will now be fully visible. Before that the highlighter (for visualisation) obstructed everything

- [x] I have checked that I am merging into correct branch
