### PR TITLE
Save telemetry data to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ build/
 lib/
 **/evosuite-tests/
 src/test/resources/project/pizzeria/.idea/
+src/test/resources/project/pizzeria/target/
 src/test/resources/project/.idea/
 src/test/resources/project/untitled/.idea/

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
@@ -38,7 +38,7 @@ class TestGenieTelemetrySubmitListenerImpl : ProjectManagerListener {
                         .getService(TestGenieTelemetryService::class.java).submitTelemetry()
                 }
             },
-            10000, 10000
+            300000, 300000
         )
     }
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
@@ -22,15 +22,23 @@ class TestGenieTelemetrySubmitListenerImpl : ProjectManagerListener {
      * @param project the current project
      */
     override fun projectOpened(project: Project) {
-        Timer().scheduleAtFixedRate(
+        val timer = Timer()
+        timer.scheduleAtFixedRate(
             object : TimerTask() {
                 override fun run() {
-                    log.info("Checking generated telemetry...")
+                    // Cancel the timer if the project is closed
+                    if (!project.isOpen) {
+                        timer.cancel()
+                        return
+                    }
+
+                    log.info("Checking generated telemetry for the project ${project.name}...")
+
                     ApplicationManager.getApplication()
                         .getService(TestGenieTelemetryService::class.java).submitTelemetry()
                 }
             },
-            300000, 300000
+            10000, 10000
         )
     }
 
@@ -40,7 +48,7 @@ class TestGenieTelemetrySubmitListenerImpl : ProjectManagerListener {
      * @param project the current project
      */
     override fun projectClosing(project: Project) {
-        log.info("Checking generated telemetry...")
+        log.info("Checking generated telemetry for the project ${project.name} before closing...")
 
         ApplicationManager.getApplication()
             .getService(TestGenieTelemetryService::class.java).submitTelemetry()

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
@@ -7,9 +7,19 @@ import com.intellij.openapi.project.ProjectManagerListener
 import nl.tudelft.ewi.se.ciselab.testgenie.services.TestGenieTelemetryService
 import java.util.*
 
+/**
+ * This class is responsible for scheduling potential submissions of telemetry into a file, which is done every 5 minutes,
+ *   as well as attempting to do it when the project is closed.
+ */
 class TestGenieTelemetrySubmitListenerImpl : ProjectManagerListener {
     private val log = Logger.getInstance(this.javaClass)
 
+    /**
+     * Schedules attempts to submit the telemetry into a file.
+     * The attempts are done every 5 minutes and is first done 5 minutes after opening a project.
+     *
+     * @param project the current project
+     */
     override fun projectOpened(project: Project) {
         Timer().scheduleAtFixedRate(
             object : TimerTask() {
@@ -23,6 +33,11 @@ class TestGenieTelemetrySubmitListenerImpl : ProjectManagerListener {
         )
     }
 
+    /**
+     * Attempts to submit the telemetry into a file when the project is closed.
+     *
+     * @param project the current project
+     */
     override fun projectClosing(project: Project) {
         log.info("Checking generated telemetry...")
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
@@ -1,0 +1,17 @@
+package nl.tudelft.ewi.se.ciselab.testgenie.listener
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManagerListener
+import nl.tudelft.ewi.se.ciselab.testgenie.services.TestGenieTelemetryService
+
+class TestGenieTelemetrySubmitListenerImpl : ProjectManagerListener {
+    private val log = Logger.getInstance(this.javaClass)
+
+    override fun projectClosing(project: Project) {
+        log.info("Saving generated telemetry...")
+
+        ApplicationManager.getApplication().getService(TestGenieTelemetryService::class.java).submitTelemetry()
+    }
+}

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
@@ -5,7 +5,8 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
 import nl.tudelft.ewi.se.ciselab.testgenie.services.TestGenieTelemetryService
-import java.util.*
+import java.util.Timer
+import java.util.TimerTask
 
 /**
  * This class is responsible for scheduling potential submissions of telemetry into a file, which is done every 5 minutes,

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/listener/TestGenieTelemetrySubmitListenerImpl.kt
@@ -5,13 +5,28 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
 import nl.tudelft.ewi.se.ciselab.testgenie.services.TestGenieTelemetryService
+import java.util.*
 
 class TestGenieTelemetrySubmitListenerImpl : ProjectManagerListener {
     private val log = Logger.getInstance(this.javaClass)
 
-    override fun projectClosing(project: Project) {
-        log.info("Saving generated telemetry...")
+    override fun projectOpened(project: Project) {
+        Timer().scheduleAtFixedRate(
+            object : TimerTask() {
+                override fun run() {
+                    log.info("Checking generated telemetry...")
+                    ApplicationManager.getApplication()
+                        .getService(TestGenieTelemetryService::class.java).submitTelemetry()
+                }
+            },
+            300000, 300000
+        )
+    }
 
-        ApplicationManager.getApplication().getService(TestGenieTelemetryService::class.java).submitTelemetry()
+    override fun projectClosing(project: Project) {
+        log.info("Checking generated telemetry...")
+
+        ApplicationManager.getApplication()
+            .getService(TestGenieTelemetryService::class.java).submitTelemetry()
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -252,7 +252,7 @@ class TestCaseDisplayService(private val project: Project) {
         )
 
         // TODO: Upload to server in the background instead of here
-        telemetryService.submitTelemetry()
+//        telemetryService.submitTelemetry()
     }
 
     private fun validateTests() {}

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -251,8 +251,8 @@ class TestCaseDisplayService(private val project: Project) {
             }
         )
 
-        // TODO: Upload to server in the background instead of here
-//        telemetryService.submitTelemetry()
+        // The scheduled tests will be submitted in the background
+        // (they will be checked every 5 minutes and also when the project is closed)
     }
 
     private fun validateTests() {}

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -252,7 +252,7 @@ class TestCaseDisplayService(private val project: Project) {
         )
 
         // TODO: Upload to server in the background instead of here
-        telemetryService.uploadTelemetry()
+        telemetryService.submitTelemetry()
     }
 
     private fun validateTests() {}

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -65,7 +65,7 @@ class TestGenieTelemetryService {
      */
     private fun writeTelemetryToFile(json: String) {
         // Get the separator depending on the underlying OS
-        val separator: String = if (System.getProperty("os.name").contains("Windows")) "\\" else "/"
+        val separator: String = java.io.File.separator
         // Get the telemetry path
         var dirName: String = TestGenieSettingsService.getInstance().state?.telemetryPath
             ?: System.getProperty("user.dir")
@@ -78,7 +78,7 @@ class TestGenieTelemetryService {
         }
 
         // Get the file name based on the current timestamp
-        val telemetryFileName: String = dirName.plus(Timestamp(System.currentTimeMillis()).toString())
+        val telemetryFileName: String = dirName.plus(Timestamp(System.currentTimeMillis()).toString()).plus(".json")
 
         log.info("Saving telemetry into ".plus(telemetryFileName))
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -50,7 +50,7 @@ class TestGenieTelemetryService {
         val json = gson.toJson(testCasesToUpload)
         log.info("Uploading test cases: $json")
 
-        marti(json)
+        writeTelemetryToFile(json)
     }
 
     /**
@@ -58,7 +58,7 @@ class TestGenieTelemetryService {
      *
      * @param json a json object with the telemetry
      */
-    private fun marti(json: String) {
+    private fun writeTelemetryToFile(json: String) {
         // Get the separator depending on the underlying OS
         val separator: String = if (System.getProperty("os.name").contains("Windows")) "\\" else "/"
         // Get the telemetry path
@@ -75,7 +75,7 @@ class TestGenieTelemetryService {
         // Get the file name based on the current timestamp
         val telemetryFileName: String = dirName.plus(Timestamp(System.currentTimeMillis()).toString())
 
-        log.info("log4j: Saving telemetry into ".plus(telemetryFileName))
+        log.info("Saving telemetry into ".plus(telemetryFileName))
 
         // Write the json to the file
         File(telemetryFileName).bufferedWriter().use { out -> out.write(json) }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -49,7 +49,7 @@ class TestGenieTelemetryService {
             return
         }
 
-        log.info("Submiting ${testCasesToSubmit.size} test cases to server")
+        log.info("Submiting ${testCasesToSubmit.size} test cases to a file")
 
         val gson = Gson()
         val json = gson.toJson(testCasesToSubmit)

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -2,6 +2,8 @@ package nl.tudelft.ewi.se.ciselab.testgenie.services
 
 import com.google.gson.Gson
 import com.intellij.openapi.diagnostic.Logger
+import java.io.File
+import java.sql.Timestamp
 
 class TestGenieTelemetryService {
     private val modifiedTestCases = mutableListOf<ModifiedTestCase>()
@@ -48,7 +50,8 @@ class TestGenieTelemetryService {
         val json = gson.toJson(testCasesToUpload)
         log.info("Uploading test cases: $json")
 
-        // TODO: Actually upload test cases to server
+        // TODO: Actually upload test cases to a file
+        File(Timestamp(System.currentTimeMillis()).toString()).bufferedWriter().use { out -> out.write(json) }
     }
 
     class ModifiedTestCase(val original: String, val modified: String)

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -3,13 +3,15 @@ package nl.tudelft.ewi.se.ciselab.testgenie.services
 import com.google.gson.Gson
 import com.intellij.openapi.diagnostic.Logger
 import java.io.File
-import java.sql.Timestamp
+import java.text.SimpleDateFormat
+import java.util.Date
 
 class TestGenieTelemetryService {
     private val modifiedTestCases = mutableListOf<ModifiedTestCase>()
     private val modifiedTestCasesLock = Object()
 
     private val log: Logger = Logger.getInstance(this.javaClass)
+    private val dateFormatter: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss")
 
     private val telemetryEnabled: Boolean
         get() = TestGenieSettingsService.getInstance().state?.telemetryEnabled ?: false
@@ -78,7 +80,8 @@ class TestGenieTelemetryService {
         }
 
         // Get the file name based on the current timestamp
-        val telemetryFileName: String = dirName.plus(Timestamp(System.currentTimeMillis()).toString()).plus(".json")
+        val currentTime: String = dateFormatter.format(Date())
+        val telemetryFileName: String = dirName.plus(currentTime).plus(".json")
 
         log.info("Saving telemetry into ".plus(telemetryFileName))
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -37,18 +37,23 @@ class TestGenieTelemetryService {
             return
         }
 
-        val testCasesToUpload = mutableListOf<ModifiedTestCase>()
+        val testCasesToSubmit = mutableListOf<ModifiedTestCase>()
 
         synchronized(modifiedTestCasesLock) {
-            testCasesToUpload.addAll(modifiedTestCases)
+            testCasesToSubmit.addAll(modifiedTestCases)
             modifiedTestCases.clear()
         }
 
-        log.info("Uploading ${testCasesToUpload.size} test cases to server")
+        // If there are no tests to submit, do not create a file
+        if (testCasesToSubmit.size == 0) {
+            return
+        }
+
+        log.info("Submiting ${testCasesToSubmit.size} test cases to server")
 
         val gson = Gson()
-        val json = gson.toJson(testCasesToUpload)
-        log.info("Uploading test cases: $json")
+        val json = gson.toJson(testCasesToSubmit)
+        log.info("Submiting test cases: $json")
 
         writeTelemetryToFile(json)
     }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -30,9 +30,9 @@ class TestGenieTelemetryService {
     }
 
     /**
-     * Sends the telemetry to the TestGenie server.
+     * Saves the telemetry to a file.
      */
-    fun uploadTelemetry() {
+    fun submitTelemetry() {
         if (!telemetryEnabled) {
             return
         }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestGenieTelemetryService.kt
@@ -50,8 +50,35 @@ class TestGenieTelemetryService {
         val json = gson.toJson(testCasesToUpload)
         log.info("Uploading test cases: $json")
 
-        // TODO: Actually upload test cases to a file
-        File(Timestamp(System.currentTimeMillis()).toString()).bufferedWriter().use { out -> out.write(json) }
+        marti(json)
+    }
+
+    /**
+     * Writes a json with the telemetry to a file.
+     *
+     * @param json a json object with the telemetry
+     */
+    private fun marti(json: String) {
+        // Get the separator depending on the underlying OS
+        val separator: String = if (System.getProperty("os.name").contains("Windows")) "\\" else "/"
+        // Get the telemetry path
+        var dirName: String = TestGenieSettingsService.getInstance().state?.telemetryPath
+            ?: System.getProperty("user.dir")
+        if (!dirName.endsWith(separator)) dirName = dirName.plus(separator)
+
+        // Create the directory if it does not exist
+        val dir = File(dirName)
+        if (!dir.exists()) {
+            dir.mkdirs()
+        }
+
+        // Get the file name based on the current timestamp
+        val telemetryFileName: String = dirName.plus(Timestamp(System.currentTimeMillis()).toString())
+
+        log.info("log4j: Saving telemetry into ".plus(telemetryFileName))
+
+        // Write the json to the file
+        File(telemetryFileName).bufferedWriter().use { out -> out.write(json) }
     }
 
     class ModifiedTestCase(val original: String, val modified: String)

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
@@ -48,7 +48,7 @@ class SettingsPluginComponent {
     )
     private val telemetrySeparator = JXTitledSeparator("Telemetry")
     private var telemetryEnabledCheckbox = JCheckBox("Enable telemetry")
-    private val telemetryPathTextField = JTextField(System.getProperty("user.dir"))
+    private val telemetryPathTextField = JTextField(TestGenieSettingsState.DefaultSettingsState.telemetryPath)
 
     // Accessibility options
     private val accessibilitySeparator = JXTitledSeparator("Accessibility settings")

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
@@ -80,7 +80,7 @@ class SettingsPluginComponent {
             .addComponent(telemetrySeparator, 15)
             .addComponent(telemetryDescription, 10)
             .addComponent(telemetryEnabledCheckbox, 10)
-            .addComponent(telemetryPathTextField, 10)
+            .addLabeledComponent(JBLabel("Specify the folder path for telemetry data"), telemetryPathTextField, 10, false)
             // Add accessibility options
             .addComponent(accessibilitySeparator, 15)
             .addComponent(JBLabel("Choose color for visualisation highlight"), 15)
@@ -122,6 +122,7 @@ class SettingsPluginComponent {
         pluginDescription.preferredSize = Dimension(width ?: 100, height ?: 100)
         pluginDescriptionDisclaimer.preferredSize = Dimension(width ?: 100, height ?: 100)
         telemetryDescription.preferredSize = Dimension(width ?: 100, height ?: 100)
+        telemetryPathTextField.preferredSize = Dimension(width ?: 100, telemetryPathTextField.preferredSize.height)
 
         // Set colorPicker to wrap around dimensions
         colorPicker.preferredSize = Dimension(width ?: 100, height ?: 400)

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
@@ -105,7 +105,7 @@ class SettingsPluginComponent {
         telemetryEnabledCheckbox.toolTipText = "Send telemetry to CISELab"
 
         // Add description to telemetry path
-        telemetryPathTextField.toolTipText = "Choose a file to save the changes into"
+        telemetryPathTextField.toolTipText = "Choose a directory to save telemetry data into"
 
         // Get dimensions of visible rectangle
         val width = panel?.visibleRect?.width

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
@@ -48,6 +48,7 @@ class SettingsPluginComponent {
     )
     private val telemetrySeparator = JXTitledSeparator("Telemetry")
     private var telemetryEnabledCheckbox = JCheckBox("Enable telemetry")
+    private val telemetryPathTextField = JTextField(System.getProperty("user.dir"))
 
     // Accessibility options
     private val accessibilitySeparator = JXTitledSeparator("Accessibility settings")
@@ -79,6 +80,7 @@ class SettingsPluginComponent {
             .addComponent(telemetrySeparator, 15)
             .addComponent(telemetryDescription, 10)
             .addComponent(telemetryEnabledCheckbox, 10)
+            .addComponent(telemetryPathTextField, 10)
             // Add accessibility options
             .addComponent(accessibilitySeparator, 15)
             .addComponent(JBLabel("Choose color for visualisation highlight"), 15)
@@ -101,6 +103,9 @@ class SettingsPluginComponent {
 
         // Add description to telemetry
         telemetryEnabledCheckbox.toolTipText = "Send telemetry to CISELab"
+
+        // Add description to telemetry path
+        telemetryPathTextField.toolTipText = "Choose a file to save the changes into"
 
         // Get dimensions of visible rectangle
         val width = panel?.visibleRect?.width
@@ -157,6 +162,12 @@ class SettingsPluginComponent {
         get() = telemetryEnabledCheckbox.isSelected
         set(newStatus) {
             telemetryEnabledCheckbox.isSelected = newStatus
+        }
+
+    var telemetryPath: String
+        get() = telemetryPathTextField.text
+        set(newPath) {
+            telemetryPathTextField.text = newPath
         }
 
     var colorRed: Int

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginConfigurable.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginConfigurable.kt
@@ -35,6 +35,7 @@ class SettingsPluginConfigurable : Configurable {
         settingsComponent!!.colorBlue = settingsState.colorBlue
         settingsComponent!!.buildCommand = settingsState.buildCommand
         settingsComponent!!.telemetryEnabled = settingsState.telemetryEnabled
+        settingsComponent!!.telemetryPath = settingsState.telemetryPath
     }
 
     /**
@@ -51,6 +52,7 @@ class SettingsPluginConfigurable : Configurable {
         modified = modified or (settingsComponent!!.colorBlue != settingsState.colorBlue)
         modified = modified or (settingsComponent!!.buildCommand != settingsState.buildCommand)
         modified = modified or (settingsComponent!!.telemetryEnabled != settingsState.telemetryEnabled)
+        modified = modified or (settingsComponent!!.telemetryPath != settingsState.telemetryPath)
         return modified
     }
 
@@ -66,6 +68,7 @@ class SettingsPluginConfigurable : Configurable {
         settingsState.buildPath = settingsComponent!!.buildPath
         settingsState.buildCommand = settingsComponent!!.buildCommand
         settingsState.telemetryEnabled = settingsComponent!!.telemetryEnabled
+        settingsState.telemetryPath = settingsComponent!!.telemetryPath
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import nl.tudelft.ewi.se.ciselab.testgenie.TestGenieDefaultsBundle
+import org.apache.commons.io.FilenameUtils
 import java.io.File
 
 /**
@@ -60,14 +61,13 @@ data class TestGenieSettingsState(
          *   which is in the project folder if there is a project, or in the home directory if not
          */
         private fun createDefaultTelemetryPath(): String {
-            val suffix = "TestGenieTelemetry"
+            val suffix = TestGenieDefaultsBundle.defaultValue("telemetryDirectory")
             val backupDefaultTelemetryPath: String = System.getProperty("user.home").plus(suffix)
 
             val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(2000)
                 ?: return backupDefaultTelemetryPath
             val projectBasePath: String = CommonDataKeys.PROJECT.getData(dataContext)?.basePath
                 ?: return backupDefaultTelemetryPath
-
             return "$projectBasePath${File.separator}$suffix"
         }
     }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -4,7 +4,6 @@ import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import nl.tudelft.ewi.se.ciselab.testgenie.TestGenieDefaultsBundle
-import org.apache.commons.io.FilenameUtils
 import java.io.File
 
 /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -29,7 +29,8 @@ data class TestGenieSettingsState(
     var colorBlue: Int = DefaultSettingsState.colorBlue,
     var buildPath: String = DefaultSettingsState.buildPath,
     var buildCommand: String = DefaultSettingsState.buildCommand,
-    var telemetryEnabled: Boolean = DefaultSettingsState.telemetryEnabled
+    var telemetryEnabled: Boolean = DefaultSettingsState.telemetryEnabled,
+    var telemetryPath: String = DefaultSettingsState.telemetryPath
 ) {
     private object DefaultSettingsState {
         const val sandbox: Boolean = true
@@ -45,6 +46,7 @@ data class TestGenieSettingsState(
         val buildPath: String = TestGenieDefaultsBundle.defaultValue("buildPath")
         val buildCommand: String = TestGenieDefaultsBundle.defaultValue("buildCommand")
         val telemetryEnabled: Boolean = TestGenieDefaultsBundle.defaultValue("telemetryEnabled").toBoolean()
+        val telemetryPath: String = System.getProperty("user.dir")
     }
 
     fun serializeChangesFromDefault(): List<String> {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,9 @@
         <listener
                 class="nl.tudelft.ewi.se.ciselab.testgenie.listener.TestGenerationResultListenerImpl"
                 topic="nl.tudelft.ewi.se.ciselab.testgenie.evosuite.TestGenerationResultListener"/>
+        <listener
+                class="nl.tudelft.ewi.se.ciselab.testgenie.listener.TestGenieTelemetrySubmitListenerImpl"
+                topic="com.intellij.openapi.project.ProjectManagerListener"/>
     </projectListeners>
 
     <actions>

--- a/src/main/resources/defaults/TestGenie.properties
+++ b/src/main/resources/defaults/TestGenie.properties
@@ -14,4 +14,4 @@ buildPath=target/classes
 showCoverage=true
 buildCommand=mvn compile
 telemetryEnabled=false
-telemetryDirectory=TestGenieTelemetry 
+telemetryDirectory=TestGenieTelemetry

--- a/src/main/resources/defaults/TestGenie.properties
+++ b/src/main/resources/defaults/TestGenie.properties
@@ -14,3 +14,4 @@ buildPath=target/classes
 showCoverage=true
 buildCommand=mvn compile
 telemetryEnabled=false
+telemetryDirectory=TestGenieTelemetry 


### PR DESCRIPTION
# Description of changes made
- Telemetry data is now saved into a *json* file in a user-specified folder
- Every time `submitTelemetry` method in the telemetry service is called, a new file in that directory is created using the *current timestamp* as the filename, and *all currently scheduled tests* are saved to that file. If there is no currently scheduled tests, no file is created
- `submitTelemetry` method is now called every 5 minutes and when intellij exits

# Why is merge request needed
This merge request is needed since it is part of a feature requested by the client

# Other notes
Closes #139 

# What is missing?

- [x] I have checked that I am merging into correct branch
