### PR TITLE
Remove tests from cache

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
@@ -20,6 +20,7 @@ import nl.tudelft.ewi.se.ciselab.testgenie.TestGenieBundle
 import nl.tudelft.ewi.se.ciselab.testgenie.Util
 import nl.tudelft.ewi.se.ciselab.testgenie.editor.Workspace
 import nl.tudelft.ewi.se.ciselab.testgenie.services.TestCaseCachingService
+import nl.tudelft.ewi.se.ciselab.testgenie.services.TestCaseDisplayService
 import nl.tudelft.ewi.se.ciselab.testgenie.services.TestGenieSettingsService
 import org.evosuite.result.TestGenerationResultImpl
 import org.evosuite.utils.CompactReport
@@ -163,6 +164,7 @@ class Runner(
                 }
             })
 
+        project.service<TestCaseDisplayService>().fileUrl = fileUrl
         return testResultName
     }
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
@@ -96,7 +96,7 @@ class TestCaseCachingService {
 
                     synchronized(caseIndexLock) {
                         if (!caseIndex.contains(cachedCompactTestCase.testCode)) {
-                            caseIndex[cachedCompactTestCase.testCode] = cachedCompactTestCase;
+                            caseIndex[cachedCompactTestCase.testCode] = cachedCompactTestCase
                         }
                     }
                 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
@@ -62,10 +62,9 @@ class TestCaseCachingService {
          */
         fun putIntoCache(report: CompactReport) {
             report.testCaseList.values.forEach { testCase ->
+                val cachedCompactTestCase = CachedCompactTestCase.fromCompactTestCase(testCase, this)
                 testCase.coveredLines.forEach { lineNumber ->
                     val line: LineTestCaseCache = getLineTestCaseCache(lineNumber)
-
-                    val cachedCompactTestCase = CachedCompactTestCase.fromCompactTestCase(testCase, this)
                     line.putIntoCache(cachedCompactTestCase)
                 }
             }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
@@ -67,6 +67,10 @@ class TestCaseCachingService {
         private val lines = mutableMapOf<Int, LineTestCaseCache>()
         private val linesLock = Object()
 
+        // Used for retrieving references of unique test cases
+        private val caseIndex = mutableMapOf<String, CachedCompactTestCase>()
+        private val caseIndexLock = Object()
+
         /**
          * Insert test cases into the file cache.
          *
@@ -78,6 +82,12 @@ class TestCaseCachingService {
                 testCase.coveredLines.forEach { lineNumber ->
                     val line: LineTestCaseCache = getLineTestCaseCache(lineNumber)
                     line.putIntoCache(cachedCompactTestCase)
+
+                    synchronized(caseIndexLock) {
+                        if (!caseIndex.contains(cachedCompactTestCase.testCode)) {
+                            caseIndex[cachedCompactTestCase.testCode] = cachedCompactTestCase;
+                        }
+                    }
                 }
             }
         }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
@@ -238,7 +238,7 @@ class TestCaseCachingService {
             ): CachedCompactTestCase {
                 return CachedCompactTestCase(
                     testCase.testName,
-                    testCase.testCode,
+                    testCase.testCode.replace("\r\n", "\n"),
                     testCase.coveredLines.map {
                         fileTestCaseCache.getLineTestCaseCache(it)
                     }.toSet()

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
@@ -37,6 +37,18 @@ class TestCaseCachingService {
     }
 
     /**
+     * Invalidate test cases from the cache.
+     *
+     * @param fileUrl the URL of the file that the test cases belong to
+     * @param lineFrom the start of the range
+     * @param lineTo the end of the ranges
+     */
+    fun invalidateFromCache(fileUrl: String, lineFrom: Int, lineTo: Int) {
+        val fileTestCaseCache = getFileTestCaseCache(fileUrl)
+        fileTestCaseCache.invalidateFromCache(lineFrom, lineTo)
+    }
+
+    /**
      * Get the file test case cache for the specified file.
      *
      * @param fileUrl the URL of the file
@@ -88,6 +100,21 @@ class TestCaseCachingService {
         }
 
         /**
+         * Invalidate test cases from cache.
+         *
+         * @param lineFrom the start of the range
+         * @param lineTo the end of the range
+         */
+        fun invalidateFromCache(lineFrom: Int, lineTo: Int) {
+            for (lineNumber in lineFrom..lineTo) {
+                val tests: LineTestCaseCache = getLineTestCaseCache(lineNumber)
+                for (test in tests.getTestCases()) {
+                    test.invalid = true
+                }
+            }
+        }
+
+        /**
          * Get the line test case cache for the specified line.
          * @return the line test case cache
          */
@@ -130,7 +157,7 @@ class TestCaseCachingService {
          */
         fun getTestCases(): List<CachedCompactTestCase> {
             synchronized(testCasesLock) {
-                return testCases.toList()
+                return testCases.filter { x -> !x.invalid }.toList()
             }
         }
     }
@@ -143,6 +170,7 @@ class TestCaseCachingService {
         val testCode: String,
         private val coveredLines: Set<LineTestCaseCache>
     ) {
+        var invalid: Boolean = false
 
         /**
          * Convert this cached test case back to a compact test case.

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
@@ -49,6 +49,17 @@ class TestCaseCachingService {
     }
 
     /**
+     * Invalidate test case from the cache.
+     *
+     * @param fileUrl the URL of the file that the test cases belong to
+     * @param testCode the code of the test case
+     */
+    fun invalidateFromCache(fileUrl: String, testCode: String) {
+        val fileTestCaseCache = getFileTestCaseCache(fileUrl)
+        fileTestCaseCache.invalidateFromCache(testCode)
+    }
+
+    /**
      * Get the file test case cache for the specified file.
      *
      * @param fileUrl the URL of the file
@@ -121,6 +132,17 @@ class TestCaseCachingService {
                 for (test in tests.getTestCases()) {
                     test.invalid = true
                 }
+            }
+        }
+
+        /**
+         * Invalidate test cases from cache.
+         *
+         * @param testCode the code of the test case
+         */
+        fun invalidateFromCache(testCode: String) {
+            synchronized(caseIndexLock) {
+                caseIndex[testCode]?.invalid = true
             }
         }
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -198,7 +198,10 @@ class TestCaseDisplayService(private val project: Project) {
             .map { it.key }
 
         // Remove the selected tests from cache
-        selectedTestCases.forEach { removeFromCache(originalTestCases[it]!!) }
+        selectedTestCases.forEach {
+            removeFromCache(originalTestCases[it]!!)
+            testCasePanels.remove(it)
+        }
 
         val testCaseComponents = selectedTestCases.map {
             testCasePanels[it]!!.getComponent(1) as EditorTextField

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -122,6 +122,14 @@ class TestCaseDisplayService(private val project: Project) {
             val topButtons = JPanel()
             topButtons.layout = FlowLayout(FlowLayout.TRAILING)
 
+            // Add "Remove From Cache"  button
+            val removeFromCacheButton = JButton("Remove From Cache")
+            removeFromCacheButton.addActionListener {
+                // TODO: actually remove from the cache
+                println("Test $testName will be removed from the cache")
+                removeFromCacheButton.isEnabled = false
+            }
+
             // Add "Reset" button
             val resetButton = JButton("Reset")
             resetButton.isEnabled = false
@@ -176,6 +184,7 @@ class TestCaseDisplayService(private val project: Project) {
                     checkbox.isSelected = true
                 }
             })
+            topButtons.add(removeFromCacheButton)
             topButtons.add(resetButton)
             testCasePanel.add(topButtons, BorderLayout.NORTH)
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -129,8 +129,8 @@ class TestCaseDisplayService(private val project: Project) {
             val topButtons = JPanel()
             topButtons.layout = FlowLayout(FlowLayout.TRAILING)
 
-            // Add "Remove From Cache"  button
-            val removeFromCacheButton = JButton("Remove From Cache")
+            // Add "Remove"  button to remove the test from cache
+            val removeFromCacheButton = JButton("Remove")
             removeFromCacheButton.addActionListener {
                 removeFromCache(testCode)
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -59,10 +59,6 @@ class TestCaseDisplayService(private val project: Project) {
     private var content: Content? = null
 
     var fileUrl: String = ""
-        get() = field
-        set(newFileUrl) {
-            field = newFileUrl
-        }
 
     init {
         allTestCasePanel.layout = BoxLayout(allTestCasePanel, BoxLayout.Y_AXIS)
@@ -157,7 +153,7 @@ class TestCaseDisplayService(private val project: Project) {
     }
 
     /**
-     * Highlight the mini-editor in the toolwindow whose name corresponds with the name of the test provided
+     * Highlight the mini-editor in the tool window whose name corresponds with the name of the test provided
      *
      * @param name name of the test whose editor should be highlighted
      */

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -132,16 +132,16 @@ class TestCaseDisplayService(private val project: Project) {
             // Add "Remove From Cache"  button
             val removeFromCacheButton = JButton("Remove From Cache")
             removeFromCacheButton.addActionListener {
-                // TODO: Update gutters when you remove tests from cache
-                val cache = project.service<TestCaseCachingService>()
-                cache.invalidateFromCache(fileUrl, testCode)
+                removeFromCache(testCode)
 
-                //
+                // Remove the highlighting of the test
                 project.messageBus.syncPublisher(COVERAGE_SELECTION_TOGGLE_TOPIC)
                     .testGenerationResult(testName, false, editor)
 
+                // Remove the test from the panels
                 testCasePanels.remove(testName)
 
+                // Update the UI
                 allTestCasePanel.remove(testCasePanel)
                 allTestCasePanel.updateUI()
             }
@@ -236,6 +236,9 @@ class TestCaseDisplayService(private val project: Project) {
     private fun applyTests() {
         val selectedTestCases = testCasePanels.filter { (it.value.getComponent(0) as JCheckBox).isSelected }
             .map { it.key }
+
+        // Remove the selected tests from cache
+        selectedTestCases.forEach { removeFromCache(originalTestCases[it]!!) }
 
         val testCaseComponents = selectedTestCases.map {
             testCasePanels[it]!!.getComponent(1) as EditorTextField
@@ -344,5 +347,15 @@ class TestCaseDisplayService(private val project: Project) {
         // Focus on generated tests tab and open toolWindow if not opened already
         contentManager.setSelectedContent(content!!)
         toolWindowManager.show()
+    }
+
+    /**
+     * A helper method to remove a test case from cache.
+     *
+     * @param testCode the source code of a test
+     */
+    private fun removeFromCache(testCode: String) {
+        val cache = project.service<TestCaseCachingService>()
+        cache.invalidateFromCache(fileUrl, testCode)
     }
 }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -129,7 +129,7 @@ class TestCaseDisplayService(private val project: Project) {
             testCasePanel.add(textFieldEditor, BorderLayout.CENTER)
 
             // Create "Remove"  button to remove the test from cache
-            val removeFromCacheButton = createRemoveButton(testCase, editor, testCasePanel)
+            val removeFromCacheButton = createRemoveButton(testCase, editor, testCasePanel, testCodeFormatted)
 
             // Create "Reset" button to reset the changes in the source code of the test
             val resetButton = createResetButton(document, textFieldEditor, testCodeFormatted)
@@ -301,10 +301,10 @@ class TestCaseDisplayService(private val project: Project) {
      * @param testCasePanel the test case panel
      * @return the created button
      */
-    private fun createRemoveButton(test: CompactTestCase, editor: Editor, testCasePanel: JPanel): JButton {
+    private fun createRemoveButton(test: CompactTestCase, editor: Editor, testCasePanel: JPanel, testCodeFormatted: String): JButton {
         val removeFromCacheButton = JButton("Remove")
         removeFromCacheButton.addActionListener {
-            removeFromCache(test.testCode)
+            removeFromCache(testCodeFormatted)
 
             // Remove the highlighting of the test
             project.messageBus.syncPublisher(COVERAGE_SELECTION_TOGGLE_TOPIC)

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.ide.util.TreeClassChooserFactory
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diff.DiffColors
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
@@ -52,6 +53,12 @@ class TestCaseDisplayService(private val project: Project) {
     // Variable to keep reference to the coverage visualisation content
     private var content: Content? = null
 
+    var fileUrl: String = ""
+        get() = field
+        set(newFileUrl) {
+            field = newFileUrl
+        }
+
     init {
         allTestCasePanel.layout = BoxLayout(allTestCasePanel, BoxLayout.Y_AXIS)
         mainPanel.layout = BorderLayout()
@@ -91,6 +98,7 @@ class TestCaseDisplayService(private val project: Project) {
         allTestCasePanel.removeAll()
         testCasePanels.clear()
         testReport.testCaseList.values.forEach {
+            val testCase = it
             val testCode = it.testCode
             val testName = it.testName
             val testCasePanel = JPanel()
@@ -127,7 +135,8 @@ class TestCaseDisplayService(private val project: Project) {
             removeFromCacheButton.addActionListener {
                 // TODO: actually remove from the cache
                 println("Test $testName will be removed from the cache")
-                removeFromCacheButton.isEnabled = false
+
+                // TODO: remove from the cache
                 allTestCasePanel.remove(testCasePanel)
                 allTestCasePanel.updateUI()
             }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseDisplayService.kt
@@ -98,7 +98,6 @@ class TestCaseDisplayService(private val project: Project) {
         allTestCasePanel.removeAll()
         testCasePanels.clear()
         testReport.testCaseList.values.forEach {
-            val testCase = it
             val testCode = it.testCode
             val testName = it.testName
             val testCasePanel = JPanel()
@@ -136,6 +135,13 @@ class TestCaseDisplayService(private val project: Project) {
                 // TODO: Update gutters when you remove tests from cache
                 val cache = project.service<TestCaseCachingService>()
                 cache.invalidateFromCache(fileUrl, testCode)
+
+                //
+                project.messageBus.syncPublisher(COVERAGE_SELECTION_TOGGLE_TOPIC)
+                    .testGenerationResult(testName, false, editor)
+
+                testCasePanels.remove(testName)
+
                 allTestCasePanel.remove(testCasePanel)
                 allTestCasePanel.updateUI()
             }

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -63,7 +63,7 @@ data class TestGenieSettingsState(
             val suffix = TestGenieDefaultsBundle.defaultValue("telemetryDirectory")
             val backupDefaultTelemetryPath: String = System.getProperty("user.home").plus(suffix)
 
-            val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(5000)
+            val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(15000)
                 ?: return backupDefaultTelemetryPath
             val projectBasePath: String = CommonDataKeys.PROJECT.getData(dataContext)?.basePath
                 ?: return backupDefaultTelemetryPath

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -63,7 +63,7 @@ data class TestGenieSettingsState(
             val suffix = TestGenieDefaultsBundle.defaultValue("telemetryDirectory")
             val backupDefaultTelemetryPath: String = System.getProperty("user.home").plus(suffix)
 
-            val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(15000)
+            val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(60000)
                 ?: return backupDefaultTelemetryPath
             val projectBasePath: String = CommonDataKeys.PROJECT.getData(dataContext)?.basePath
                 ?: return backupDefaultTelemetryPath

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -63,7 +63,7 @@ data class TestGenieSettingsState(
             val suffix = TestGenieDefaultsBundle.defaultValue("telemetryDirectory")
             val backupDefaultTelemetryPath: String = System.getProperty("user.home").plus(suffix)
 
-            val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(2000)
+            val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(5000)
                 ?: return backupDefaultTelemetryPath
             val projectBasePath: String = CommonDataKeys.PROJECT.getData(dataContext)?.basePath
                 ?: return backupDefaultTelemetryPath

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingServiceTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingServiceTest.kt
@@ -72,6 +72,60 @@ class TestCaseCachingServiceTest {
     }
 
     @Test
+    fun invalidateSingleTest() {
+        val report = CompactReport(TestGenerationResultImpl())
+        val test1 = CompactTestCase("a", "aa", setOf(1, 2), setOf(), setOf())
+        val test2 = CompactTestCase("b", "bb", setOf(2, 3), setOf(), setOf())
+        report.testCaseList = hashMapOf(
+            createPair(test1),
+            createPair(test2)
+        )
+
+        val file = "file"
+
+        testCaseCachingService.putIntoCache(file, report)
+
+        testCaseCachingService.invalidateFromCache(file, test2.testCode)
+
+        val result = testCaseCachingService.retrieveFromCache(file, 2, 2)
+
+        assertThat(result)
+            .extracting<Triple<String, String, Set<Int>>> {
+                Triple(it.testName.split(' ')[0], it.testCode, it.coveredLines)
+            }
+            .containsExactlyInAnyOrder(
+                createTriple(test1)
+            )
+    }
+
+    @Test
+    fun invalidateNonexistentSingleTest() {
+        val report = CompactReport(TestGenerationResultImpl())
+        val test1 = CompactTestCase("a", "aa", setOf(1, 2), setOf(), setOf())
+        val test2 = CompactTestCase("b", "bb", setOf(2, 3), setOf(), setOf())
+        report.testCaseList = hashMapOf(
+            createPair(test1),
+            createPair(test2)
+        )
+
+        val file = "file"
+
+        testCaseCachingService.putIntoCache(file, report)
+        testCaseCachingService.invalidateFromCache(file, "invaid")
+
+        val result = testCaseCachingService.retrieveFromCache(file, 2, 2)
+
+        assertThat(result)
+            .extracting<Triple<String, String, Set<Int>>> {
+                Triple(it.testName.split(' ')[0], it.testCode, it.coveredLines)
+            }
+            .containsExactlyInAnyOrder(
+                createTriple(test1),
+                createTriple(test2)
+            )
+    }
+
+    @Test
     fun singleFileMultipleLines() {
         val report = CompactReport(TestGenerationResultImpl())
         val test1 = CompactTestCase("a", "aa", setOf(1, 2), setOf(), setOf())


### PR DESCRIPTION
# Description of changes made
It is now possible to **manually remove the cached tests**  from the cache. It is done when the user *selects* a test or *removes* it manually.

In addition, *TestCaseDisplayService* class has been refactored a bit.

# Why is merge request needed
This merge request adds part of the caching functionality which has been requested by our client.

# Other notes
Closes #134

# What is missing?
- *"Generate More Tests"* button (not part of this merge request though)
- *"Invalidate Cache"* button - this has to be discussed with the team and with the client first

- [x] I have checked that I am merging into correct branch
