### PR TITLE
Fix caching service returning same test multiple times

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingService.kt
@@ -161,6 +161,26 @@ class TestCaseCachingService {
             )
         }
 
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as CachedCompactTestCase
+
+            if (testName != other.testName) return false
+            if (testCode != other.testCode) return false
+            if (coveredLines != other.coveredLines) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = testName.hashCode()
+            result = 31 * result + testCode.hashCode()
+            result = 31 * result + coveredLines.hashCode()
+            return result
+        }
+
         companion object {
 
             /**

--- a/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingServiceTest.kt
+++ b/src/test/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/TestCaseCachingServiceTest.kt
@@ -166,6 +166,29 @@ class TestCaseCachingServiceTest {
     }
 
     @Test
+    fun testCoversMultipleLinesInRange() {
+        val report = CompactReport(TestGenerationResultImpl())
+        val test1 = CompactTestCase("a", "aa", setOf(4, 5), setOf(), setOf())
+        report.testCaseList = hashMapOf(
+            createPair(test1)
+        )
+
+        val file = "file"
+
+        testCaseCachingService.putIntoCache(file, report)
+
+        val result = testCaseCachingService.retrieveFromCache(file, 1, 10)
+
+        assertThat(result)
+            .extracting<Triple<String, String, Set<Int>>> {
+                Triple(it.testName.split(' ')[0], it.testCode, it.coveredLines)
+            }
+            .containsExactlyInAnyOrder(
+                createTriple(test1)
+            )
+    }
+
+    @Test
     fun nonexistentFile() {
         val report = CompactReport(TestGenerationResultImpl())
         val test1 = CompactTestCase("a", "aa", setOf(1, 2), setOf(), setOf())


### PR DESCRIPTION
# Description of changes made
 The caching service could return the same test multiple times if the test covers more than one line in the requested range.

# Why is merge request needed
To fix the bug

# Other notes
Closes #151 

This was actually found while implementing #150 :smile: