### PR TITLE
Telemetry Path Bugfix

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.ui.TextBrowseFolderListener
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.FormBuilder
+import nl.tudelft.ewi.se.ciselab.testgenie.services.TestGenieSettingsService
 import org.jdesktop.swingx.JXTitledSeparator
 import java.awt.Color
 import java.awt.Dimension
@@ -66,6 +67,21 @@ class SettingsPluginComponent {
 
         // Create panel
         createSettingsPanel()
+        // Create telemetry file chooser field
+        telemetryPathField()
+    }
+
+    private fun telemetryPathField() {
+        // Watch for the checkbox being clicked
+        telemetryEnabledCheckbox.addActionListener {
+            // If checkbox is clicked, change the path chooser according to the new status
+            telemetryPathChooser.isEditable = telemetryEnabledCheckbox.isSelected
+            telemetryPathChooser.isEnabled = telemetryEnabledCheckbox.isSelected
+        }
+        val telemetryEnabled = TestGenieSettingsService.getInstance().state!!.telemetryEnabled
+        telemetryPathChooser.addBrowseFolderListener(textBrowseFolderListener) // Add the ability to choose folders
+        telemetryPathChooser.isEditable = telemetryEnabled
+        telemetryPathChooser.isEnabled = telemetryEnabled
     }
 
     /**
@@ -93,8 +109,6 @@ class SettingsPluginComponent {
             .addComponent(colorPicker, 10)
             .addComponentFillVertically(JPanel(), 0)
             .panel
-        // Add functionality to choose folder to TextFieldWithBrowseButton
-        telemetryPathChooser.addBrowseFolderListener(textBrowseFolderListener)
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginComponent.kt
@@ -1,5 +1,8 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.settings
 
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.ui.TextBrowseFolderListener
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.FormBuilder
 import org.jdesktop.swingx.JXTitledSeparator
@@ -48,7 +51,10 @@ class SettingsPluginComponent {
     )
     private val telemetrySeparator = JXTitledSeparator("Telemetry")
     private var telemetryEnabledCheckbox = JCheckBox("Enable telemetry")
-    private val telemetryPathTextField = JTextField(TestGenieSettingsState.DefaultSettingsState.telemetryPath)
+    private val fileChooserDescriptor = FileChooserDescriptor(false, true, false, false, false, false)
+    private val textBrowseFolderListener = TextBrowseFolderListener(fileChooserDescriptor)
+    private val telemetryPathChooser = TextFieldWithBrowseButton()
+    private val telemetryPathLabel = JBLabel("Specify the folder path for telemetry data")
 
     // Accessibility options
     private val accessibilitySeparator = JXTitledSeparator("Accessibility settings")
@@ -80,13 +86,15 @@ class SettingsPluginComponent {
             .addComponent(telemetrySeparator, 15)
             .addComponent(telemetryDescription, 10)
             .addComponent(telemetryEnabledCheckbox, 10)
-            .addLabeledComponent(JBLabel("Specify the folder path for telemetry data"), telemetryPathTextField, 10, false)
+            .addLabeledComponent(telemetryPathLabel, telemetryPathChooser, 10, false)
             // Add accessibility options
             .addComponent(accessibilitySeparator, 15)
             .addComponent(JBLabel("Choose color for visualisation highlight"), 15)
             .addComponent(colorPicker, 10)
             .addComponentFillVertically(JPanel(), 0)
             .panel
+        // Add functionality to choose folder to TextFieldWithBrowseButton
+        telemetryPathChooser.addBrowseFolderListener(textBrowseFolderListener)
     }
 
     /**
@@ -105,7 +113,7 @@ class SettingsPluginComponent {
         telemetryEnabledCheckbox.toolTipText = "Send telemetry to CISELab"
 
         // Add description to telemetry path
-        telemetryPathTextField.toolTipText = "Choose a directory to save telemetry data into"
+        telemetryPathLabel.toolTipText = "Choose a directory to save telemetry data into"
 
         // Get dimensions of visible rectangle
         val width = panel?.visibleRect?.width
@@ -122,7 +130,7 @@ class SettingsPluginComponent {
         pluginDescription.preferredSize = Dimension(width ?: 100, height ?: 100)
         pluginDescriptionDisclaimer.preferredSize = Dimension(width ?: 100, height ?: 100)
         telemetryDescription.preferredSize = Dimension(width ?: 100, height ?: 100)
-        telemetryPathTextField.preferredSize = Dimension(width ?: 100, telemetryPathTextField.preferredSize.height)
+        telemetryPathChooser.preferredSize = Dimension(width ?: 100, telemetryPathChooser.preferredSize.height)
 
         // Set colorPicker to wrap around dimensions
         colorPicker.preferredSize = Dimension(width ?: 100, height ?: 400)
@@ -166,9 +174,9 @@ class SettingsPluginComponent {
         }
 
     var telemetryPath: String
-        get() = telemetryPathTextField.text
+        get() = telemetryPathChooser.text
         set(newPath) {
-            telemetryPathTextField.text = newPath
+            telemetryPathChooser.text = newPath
         }
 
     var colorRed: Int

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginConfigurable.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginConfigurable.kt
@@ -77,7 +77,7 @@ class SettingsPluginConfigurable : Configurable {
      * If empty, then sets to previous state. Else, keep the new one.
      */
     private fun checkEmptyTelemetryPath(settingsState: TestGenieSettingsState): Boolean {
-        if (settingsComponent!!.telemetryEnabled && settingsComponent!!.telemetryPath.isEmpty()) {
+        if (settingsComponent!!.telemetryEnabled && settingsComponent!!.telemetryPath.isBlank()) {
             settingsState.telemetryPath = settingsState.telemetryPath
             settingsComponent!!.telemetryPath = settingsState.telemetryPath
             return true

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginConfigurable.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/SettingsPluginConfigurable.kt
@@ -68,7 +68,21 @@ class SettingsPluginConfigurable : Configurable {
         settingsState.buildPath = settingsComponent!!.buildPath
         settingsState.buildCommand = settingsComponent!!.buildCommand
         settingsState.telemetryEnabled = settingsComponent!!.telemetryEnabled
+        if (checkEmptyTelemetryPath(settingsState)) return
         settingsState.telemetryPath = settingsComponent!!.telemetryPath
+    }
+
+    /**
+     * Check if the telemetry path is empty when telemetry is enabled.
+     * If empty, then sets to previous state. Else, keep the new one.
+     */
+    private fun checkEmptyTelemetryPath(settingsState: TestGenieSettingsState): Boolean {
+        if (settingsComponent!!.telemetryEnabled && settingsComponent!!.telemetryPath.isEmpty()) {
+            settingsState.telemetryPath = settingsState.telemetryPath
+            settingsComponent!!.telemetryPath = settingsState.telemetryPath
+            return true
+        }
+        return false
     }
 
     /**

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -1,10 +1,6 @@
 package nl.tudelft.ewi.se.ciselab.testgenie.settings
 
-import com.intellij.ide.DataManager
-import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.actionSystem.DataContext
 import nl.tudelft.ewi.se.ciselab.testgenie.TestGenieDefaultsBundle
-import java.io.File
 
 /**
  * This class is the actual data class that stores the values of the Settings entries.
@@ -51,24 +47,7 @@ data class TestGenieSettingsState(
         val buildPath: String = TestGenieDefaultsBundle.defaultValue("buildPath")
         val buildCommand: String = TestGenieDefaultsBundle.defaultValue("buildCommand")
         val telemetryEnabled: Boolean = TestGenieDefaultsBundle.defaultValue("telemetryEnabled").toBoolean()
-        val telemetryPath: String = createDefaultTelemetryPath()
-
-        /**
-         * Creates a default telemetry path.
-         *
-         * @return the created default telemetry path
-         *   which is in the project folder if there is a project, or in the home directory if not
-         */
-        private fun createDefaultTelemetryPath(): String {
-            val suffix = TestGenieDefaultsBundle.defaultValue("telemetryDirectory")
-            val backupDefaultTelemetryPath: String = System.getProperty("user.home").plus(suffix)
-
-            val dataContext: DataContext = DataManager.getInstance().dataContextFromFocusAsync.blockingGet(60000)
-                ?: return backupDefaultTelemetryPath
-            val projectBasePath: String = CommonDataKeys.PROJECT.getData(dataContext)?.basePath
-                ?: return backupDefaultTelemetryPath
-            return "$projectBasePath${File.separator}$suffix"
-        }
+        val telemetryPath: String = String()
     }
 
     fun serializeChangesFromDefault(): List<String> {

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/settings/TestGenieSettingsState.kt
@@ -47,7 +47,7 @@ data class TestGenieSettingsState(
         val buildPath: String = TestGenieDefaultsBundle.defaultValue("buildPath")
         val buildCommand: String = TestGenieDefaultsBundle.defaultValue("buildCommand")
         val telemetryEnabled: Boolean = TestGenieDefaultsBundle.defaultValue("telemetryEnabled").toBoolean()
-        val telemetryPath: String = String()
+        val telemetryPath: String = System.getProperty("user.home")
     }
 
     fun serializeChangesFromDefault(): List<String> {

--- a/src/main/resources/defaults/TestGenie.properties
+++ b/src/main/resources/defaults/TestGenie.properties
@@ -14,4 +14,3 @@ buildPath=target/classes
 showCoverage=true
 buildCommand=mvn compile
 telemetryEnabled=false
-telemetryDirectory=TestGenieTelemetry


### PR DESCRIPTION
# Description of changes made
1. Replace the text field for the telemetry path with a text filed with a browse button. 
2. Delete the old default telemetry path settings.
3. Ensure that telemetry path can not be touched until the telemetry checkbox is set to true. 
4. In case the telemetry path is empty, reset the telemetry path back to previous state. 

# Why is merge request needed
The merge is needed in order to address the possible exception that is thrown on Jegor's, arch btw, machine. This will now set the default path to be user.home. Furthermore, the person can now choose the path through the file chooser. This should take care of all errors. 

# Other notes
Closes #155

*Please write if you have anything to add*
According to IntelliJ documentation the component responsible for path should have "filename completion", however this is not the case in this pull request. I suspect that this is because the feature is only allowing to select folders and not files, or because we do not provide a project variable. This is just a side note. Everything should be okay. 

# What is missing?
When the telemetry path is empty, the reset happens without informing the user that the reset occurred, i.e. no popup message is shown. This is done in order not to disturb the user in case the empty path was just a mistake. If needed the message can be added. 
 

- [x] I have checked that I am merging into correct branch
