### PR TITLE
Single test generation at a time

### DIFF
--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionClass.kt
@@ -3,10 +3,12 @@ package nl.tudelft.ewi.se.ciselab.testgenie.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Caret
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
 import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
+import nl.tudelft.ewi.se.ciselab.testgenie.services.RunnerService
 
 /**
  * This class contains all the logic related to generating tests for a class.
@@ -20,6 +22,11 @@ class GenerateTestsActionClass : AnAction() {
      * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun actionPerformed(e: AnActionEvent) {
+        // Return if EvoSuite is already running
+        val project = e.project ?: return
+        val runnerService = project.service<RunnerService>()
+        if (runnerService.verifyIsRunning()) return
+
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return
         val linesToInvalidateFromCache = calculateLinesToInvalidate(psiFile)
 

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionLine.kt
@@ -3,10 +3,12 @@ package nl.tudelft.ewi.se.ciselab.testgenie.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Caret
 import com.intellij.psi.PsiFile
 import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
+import nl.tudelft.ewi.se.ciselab.testgenie.services.RunnerService
 
 /**
  * This class contains all the logic related to generating tests for a line.
@@ -22,6 +24,11 @@ class GenerateTestsActionLine : AnAction() {
      * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun actionPerformed(e: AnActionEvent) {
+        // Return if EvoSuite is already running
+        val project = e.project ?: return
+        val runnerService = project.service<RunnerService>()
+        if (runnerService.verifyIsRunning()) return
+
         val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/actions/GenerateTestsActionMethod.kt
@@ -3,6 +3,7 @@ package nl.tudelft.ewi.se.ciselab.testgenie.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Document
@@ -13,6 +14,7 @@ import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import nl.tudelft.ewi.se.ciselab.testgenie.evosuite.Runner
 import nl.tudelft.ewi.se.ciselab.testgenie.helpers.generateMethodDescriptor
+import nl.tudelft.ewi.se.ciselab.testgenie.services.RunnerService
 
 /**
  * This class contains all the logic related to generating tests for a method.
@@ -28,6 +30,11 @@ class GenerateTestsActionMethod : AnAction() {
      * @param e an action event that contains useful information and corresponds to the action invoked by the user
      */
     override fun actionPerformed(e: AnActionEvent) {
+        // Return if EvoSuite is already running
+        val project = e.project ?: return
+        val runnerService = project.service<RunnerService>()
+        if (runnerService.verifyIsRunning()) return
+
         val evoSuiteRunner: Runner = createEvoSuiteRunner(e) ?: return
 
         val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE) ?: return

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/evosuite/Runner.kt
@@ -19,6 +19,7 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import nl.tudelft.ewi.se.ciselab.testgenie.TestGenieBundle
 import nl.tudelft.ewi.se.ciselab.testgenie.Util
 import nl.tudelft.ewi.se.ciselab.testgenie.editor.Workspace
+import nl.tudelft.ewi.se.ciselab.testgenie.services.RunnerService
 import nl.tudelft.ewi.se.ciselab.testgenie.services.StaticInvalidationService
 import nl.tudelft.ewi.se.ciselab.testgenie.services.TestCaseCachingService
 import nl.tudelft.ewi.se.ciselab.testgenie.services.TestCaseDisplayService
@@ -173,6 +174,10 @@ class Runner(
                     } catch (e: Exception) {
                         evosuiteError(TestGenieBundle.message("evosuiteErrorMessage").format(e.message))
                         e.printStackTrace()
+                    } finally {
+                        // Revert to previous state
+                        val runnerService = project.service<RunnerService>()
+                        runnerService.isRunning = false
                     }
                 }
             })

--- a/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/RunnerService.kt
+++ b/src/main/kotlin/nl/tudelft/ewi/se/ciselab/testgenie/services/RunnerService.kt
@@ -1,0 +1,38 @@
+package nl.tudelft.ewi.se.ciselab.testgenie.services
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+
+/**
+ * Service used for the sole purpose to limit TestGenie to generate tests only once at a time.
+ */
+class RunnerService(private val project: Project) {
+    var isRunning: Boolean = false
+
+    /**
+     * Method to show notification that test generation is already running.
+     */
+    private fun showNotification() {
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("EvoSuite Execution Error")
+            .createNotification(
+                "EvoSuite is already running",
+                "No new tests will be generated until this test generation run is complete.",
+                NotificationType.WARNING
+            )
+            .notify(project)
+    }
+
+    /**
+     * Method to verify whether EvoSuite is running or not.
+     */
+    fun verifyIsRunning(): Boolean {
+        if (isRunning) {
+            showNotification()
+            return true
+        }
+        isRunning = true
+        return false
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,8 @@
             serviceImplementation="nl.tudelft.ewi.se.ciselab.testgenie.services.TestCaseCachingService"/>
         <projectService
                 serviceImplementation="nl.tudelft.ewi.se.ciselab.testgenie.services.StaticInvalidationService"/>
+        <projectService
+                serviceImplementation="nl.tudelft.ewi.se.ciselab.testgenie.services.RunnerService"/>
 
         <toolWindow id="TestGenie" secondary="true" anchor="right"
                     factoryClass="nl.tudelft.ewi.se.ciselab.testgenie.toolwindow.TestGenieToolWindowFactory"/>


### PR DESCRIPTION
# Description of changes made
Only one test generation can be applied at a time now.
The user gets a notification if they attempt to generate more tests at a time.

# Why is merge request needed
Previously we could have multiple test generations at a time and the last generation was overwriting all the previous ones.

# Other notes
Closes #160

- [x] I have checked that I am merging into correct branch
